### PR TITLE
PAS-1271: Exchange Rate update to March2021 in DEV and PROD

### DIFF
--- a/conf/resources/xml/exrates-monthly-0321.xml
+++ b/conf/resources/xml/exrates-monthly-0321.xml
@@ -1,0 +1,1172 @@
+<?xml version="1.0"?>
+<exchangeRateMonthList Period="01/Mar/2021 to 31/Mar/2021">
+  <exchangeRate>
+    <countryName>Argentina</countryName>
+    <countryCode>AR</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>ARS</currencyCode>
+    <rateNew>125.66</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Australia</countryName>
+    <countryCode>AU</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>AUD</currencyCode>
+    <rateNew>1.7778</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Brazil</countryName>
+    <countryCode>BR</countryCode>
+    <currencyName>Real </currencyName>
+    <currencyCode>BRL</currencyCode>
+    <rateNew>7.7229</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Canada</countryName>
+    <countryCode>CA</countryCode>
+    <currencyName>Dollar</currencyName>
+    <currencyCode>CAD</currencyCode>
+    <rateNew>1.7727</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Denmark</countryName>
+    <countryCode>DK</countryCode>
+    <currencyName>Krone </currencyName>
+    <currencyCode>DKK</currencyCode>
+    <rateNew>8.6085</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Hong Kong</countryName>
+    <countryCode>HK</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>HKD</currencyCode>
+    <rateNew>10.89</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>India</countryName>
+    <countryCode>IN</countryCode>
+    <currencyName>Rupee </currencyName>
+    <currencyCode>INR</currencyCode>
+    <rateNew>101.85</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Israel</countryName>
+    <countryCode>IL</countryCode>
+    <currencyName>Shekel </currencyName>
+    <currencyCode>ILS</currencyCode>
+    <rateNew>4.5868</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Japan</countryName>
+    <countryCode>JP</countryCode>
+    <currencyName>Yen </currencyName>
+    <currencyCode>JPY</currencyCode>
+    <rateNew>147.64</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Malaysia</countryName>
+    <countryCode>MY</countryCode>
+    <currencyName>Ringgit </currencyName>
+    <currencyCode>MYR</currencyCode>
+    <rateNew>5.6801</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>New Zealand</countryName>
+    <countryCode>NZ</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>NZD</currencyCode>
+    <rateNew>1.9193</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Norway</countryName>
+    <countryCode>NO</countryCode>
+    <currencyName>Norwegian Krone </currencyName>
+    <currencyCode>NOK</currencyCode>
+    <rateNew>11.93</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Saudi Arabia</countryName>
+    <countryCode>SA</countryCode>
+    <currencyName>Riyal </currencyName>
+    <currencyCode>SAR</currencyCode>
+    <rateNew>5.2699</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Singapore</countryName>
+    <countryCode>SG</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>SGD</currencyCode>
+    <rateNew>1.859</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>South Africa</countryName>
+    <countryCode>ZA</countryCode>
+    <currencyName>Rand </currencyName>
+    <currencyCode>ZAR</currencyCode>
+    <rateNew>20.7</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>South Korea</countryName>
+    <countryCode>KR</countryCode>
+    <currencyName>Won </currencyName>
+    <currencyCode>KRW</currencyCode>
+    <rateNew>1560.3</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Sweden</countryName>
+    <countryCode>SE</countryCode>
+    <currencyName>Krona </currencyName>
+    <currencyCode>SEK</currencyCode>
+    <rateNew>11.62</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Switzerland</countryName>
+    <countryCode>CH</countryCode>
+    <currencyName>Franc </currencyName>
+    <currencyCode>CHF</currencyCode>
+    <rateNew>1.2603</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Taiwan</countryName>
+    <countryCode>TW</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>TWD</currencyCode>
+    <rateNew>39.21</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Thailand</countryName>
+    <countryCode>TH</countryCode>
+    <currencyName>Baht </currencyName>
+    <currencyCode>THB</currencyCode>
+    <rateNew>42.21</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>USA</countryName>
+    <countryCode>US</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>USD</currencyCode>
+    <rateNew>1.4051</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Eurozone</countryName>
+    <countryCode>EU</countryCode>
+    <currencyName>Euro </currencyName>
+    <currencyCode>EUR</currencyCode>
+    <rateNew>1.1577</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Abu Dhabi</countryName>
+    <countryCode>DH</countryCode>
+    <currencyName>Dirham </currencyName>
+    <currencyCode>AED</currencyCode>
+    <rateNew>5.1612</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Albania</countryName>
+    <countryCode>AL</countryCode>
+    <currencyName>Lek </currencyName>
+    <currencyCode>ALL</currencyCode>
+    <rateNew>143.11</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Algeria</countryName>
+    <countryCode>DZ</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>DZD</currencyCode>
+    <rateNew>186.89</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Angola</countryName>
+    <countryCode>AO</countryCode>
+    <currencyName>Readj Kwanza </currencyName>
+    <currencyCode>AOA</currencyCode>
+    <rateNew>914.72</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Antigua</countryName>
+    <countryCode>AG</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7938</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Armenia</countryName>
+    <countryCode>AM</countryCode>
+    <currencyName>Dram </currencyName>
+    <currencyCode>AMD</currencyCode>
+    <rateNew>737.82</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Aruba</countryName>
+    <countryCode>AA</countryCode>
+    <currencyName>Florin</currencyName>
+    <currencyCode>AWG</currencyCode>
+    <rateNew>2.5151</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Azerbaijan</countryName>
+    <countryCode>AZ</countryCode>
+    <currencyName>New Manat </currencyName>
+    <currencyCode>AZN</currencyCode>
+    <rateNew>2.3873</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bahamas</countryName>
+    <countryCode>BS</countryCode>
+    <currencyName>Dollar</currencyName>
+    <currencyCode>BSD</currencyCode>
+    <rateNew>1.4051</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bahrain</countryName>
+    <countryCode>BH</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>BHD</currencyCode>
+    <rateNew>0.5298</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bangladesh</countryName>
+    <countryCode>BD</countryCode>
+    <currencyName>Taka </currencyName>
+    <currencyCode>BDT</currencyCode>
+    <rateNew>118.97</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Barbados</countryName>
+    <countryCode>BB</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>BBD</currencyCode>
+    <rateNew>2.8102</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Belarus</countryName>
+    <countryCode>BY</countryCode>
+    <currencyName>Rouble </currencyName>
+    <currencyCode>BYN</currencyCode>
+    <rateNew>3.6568</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Belize</countryName>
+    <countryCode>BZ</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>BZD</currencyCode>
+    <rateNew>2.8102</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Benin</countryName>
+    <countryCode>BJ</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bermuda</countryName>
+    <countryCode>BM</countryCode>
+    <currencyName>Dollar (US) </currencyName>
+    <currencyCode>BMD</currencyCode>
+    <rateNew>1.4051</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bhutan</countryName>
+    <countryCode>BT</countryCode>
+    <currencyName>Ngultrum </currencyName>
+    <currencyCode>BTN</currencyCode>
+    <rateNew>101.85</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bolivia</countryName>
+    <countryCode>BO</countryCode>
+    <currencyName>Boliviano </currencyName>
+    <currencyCode>BOB</currencyCode>
+    <rateNew>9.7093</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bosnia- Herzegovinia</countryName>
+    <countryCode>BA</countryCode>
+    <currencyName>Marka </currencyName>
+    <currencyCode>BAM</currencyCode>
+    <rateNew>2.2642</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Botswana</countryName>
+    <countryCode>BW</countryCode>
+    <currencyName>Pula </currencyName>
+    <currencyCode>BWP</currencyCode>
+    <rateNew>15.24</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Brunei</countryName>
+    <countryCode>BN</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>BND</currencyCode>
+    <rateNew>1.859</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bulgaria</countryName>
+    <countryCode>BG</countryCode>
+    <currencyName>Lev </currencyName>
+    <currencyCode>BGN</currencyCode>
+    <rateNew>2.2643</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Burkina Faso</countryName>
+    <countryCode>BK</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Burundi</countryName>
+    <countryCode>BI</countryCode>
+    <currencyName>Franc </currencyName>
+    <currencyCode>BIF</currencyCode>
+    <rateNew>2755.41</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Cambodia</countryName>
+    <countryCode>KH</countryCode>
+    <currencyName>Riel </currencyName>
+    <currencyCode>KHR</currencyCode>
+    <rateNew>5718.78</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Cameroon Republic</countryName>
+    <countryCode>CM</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XAF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Cape Verde Islands</countryName>
+    <countryCode>CV</countryCode>
+    <currencyName>Escudo </currencyName>
+    <currencyCode>CVE</currencyCode>
+    <rateNew>128.18</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Cayman Islands</countryName>
+    <countryCode>KY</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>KYD</currencyCode>
+    <rateNew>1.1522</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Central African Republic</countryName>
+    <countryCode>CF</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XAF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Chad</countryName>
+    <countryCode>TD</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XAF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Chile</countryName>
+    <countryCode>CL</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>CLP</currencyCode>
+    <rateNew>995.59</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>China</countryName>
+    <countryCode>CN</countryCode>
+    <currencyName>Yuan</currencyName>
+    <currencyCode>CNY</currencyCode>
+    <rateNew>9.0885</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Colombia</countryName>
+    <countryCode>CO</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>COP</currencyCode>
+    <rateNew>5055.92</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Comoros</countryName>
+    <countryCode>KM</countryCode>
+    <currencyName>Franc </currencyName>
+    <currencyCode>KMF</currencyCode>
+    <rateNew>569.52</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Congo (Brazaville)</countryName>
+    <countryCode>CG</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XAF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Congo (DemRep)</countryName>
+    <countryCode>ZR</countryCode>
+    <currencyName>Congo Fr </currencyName>
+    <currencyCode>CDF</currencyCode>
+    <rateNew>2777.89</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Costa Rica</countryName>
+    <countryCode>CR</countryCode>
+    <currencyName>Colon </currencyName>
+    <currencyCode>CRC</currencyCode>
+    <rateNew>857.45</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Cote d'Ivoire</countryName>
+    <countryCode>CI</countryCode>
+    <currencyName>CFA Franc</currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Croatia</countryName>
+    <countryCode>HR</countryCode>
+    <currencyName>Kuna </currencyName>
+    <currencyCode>HRK</currencyCode>
+    <rateNew>8.7647</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Cuba</countryName>
+    <countryCode>CU</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>CUP</currencyCode>
+    <rateNew>1.4051</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Czech Republic</countryName>
+    <countryCode>CZ</countryCode>
+    <currencyName>Koruna </currencyName>
+    <currencyCode>CZK</currencyCode>
+    <rateNew>29.98</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Djibouti</countryName>
+    <countryCode>DJ</countryCode>
+    <currencyName>Franc </currencyName>
+    <currencyCode>DJF</currencyCode>
+    <rateNew>249.71</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Dominica</countryName>
+    <countryCode>DM</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7938</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Dominican Republic</countryName>
+    <countryCode>DO</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>DOP</currencyCode>
+    <rateNew>81.42</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Dubai</countryName>
+    <countryCode>DU</countryCode>
+    <currencyName>Dirham </currencyName>
+    <currencyCode>AED</currencyCode>
+    <rateNew>5.1612</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Ecuador</countryName>
+    <countryCode>EC</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>ECS</currencyCode>
+    <rateNew>1.4051</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Egypt</countryName>
+    <countryCode>EG</countryCode>
+    <currencyName>Pound </currencyName>
+    <currencyCode>EGP</currencyCode>
+    <rateNew>22.03</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>El Salvador</countryName>
+    <countryCode>SV</countryCode>
+    <currencyName>Colon </currencyName>
+    <currencyCode>SVC</currencyCode>
+    <rateNew>12.29</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Equatorial Guinea</countryName>
+    <countryCode>GQ</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XAF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Eritrea</countryName>
+    <countryCode>ER</countryCode>
+    <currencyName>Nakfa </currencyName>
+    <currencyCode>ERN</currencyCode>
+    <rateNew>21.07</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Ethiopia</countryName>
+    <countryCode>ET</countryCode>
+    <currencyName>Birr </currencyName>
+    <currencyCode>ETB</currencyCode>
+    <rateNew>56.2</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Fiji Islands</countryName>
+    <countryCode>FJ</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>FJD</currencyCode>
+    <rateNew>2.8445</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Fr. Polynesia</countryName>
+    <countryCode>PF</countryCode>
+    <currencyName>CFP Franc</currencyName>
+    <currencyCode>XPF</currencyCode>
+    <rateNew>138.14</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Gabon</countryName>
+    <countryCode>GA</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XAF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Gambia</countryName>
+    <countryCode>GM</countryCode>
+    <currencyName>Dalasi </currencyName>
+    <currencyCode>GMD</currencyCode>
+    <rateNew>71.73</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Georgia</countryName>
+    <countryCode>GE</countryCode>
+    <currencyName>Lari </currencyName>
+    <currencyCode>GEL</currencyCode>
+    <rateNew>4.6439</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Ghana</countryName>
+    <countryCode>GH</countryCode>
+    <currencyName>Cedi </currencyName>
+    <currencyCode>GHS</currencyCode>
+    <rateNew>8.0723</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Grenada</countryName>
+    <countryCode>GD</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7938</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Guatemala</countryName>
+    <countryCode>GT</countryCode>
+    <currencyName>Quetzal </currencyName>
+    <currencyCode>GTQ</currencyCode>
+    <rateNew>10.86</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Guinea Bissau</countryName>
+    <countryCode>GW</countryCode>
+    <currencyName>CFA Franc</currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Guinea Republic</countryName>
+    <countryCode>GN</countryCode>
+    <currencyName>Franc </currencyName>
+    <currencyCode>GNF</currencyCode>
+    <rateNew>14149.43</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Guyana</countryName>
+    <countryCode>GY</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>GYD</currencyCode>
+    <rateNew>293.7</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Haiti</countryName>
+    <countryCode>HT</countryCode>
+    <currencyName>Gourde </currencyName>
+    <currencyCode>HTG</currencyCode>
+    <rateNew>104.45</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Honduras</countryName>
+    <countryCode>HN</countryCode>
+    <currencyName>Lempira </currencyName>
+    <currencyCode>HNL</currencyCode>
+    <rateNew>33.84</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Hungary</countryName>
+    <countryCode>HU</countryCode>
+    <currencyName>Forint </currencyName>
+    <currencyCode>HUF</currencyCode>
+    <rateNew>415.72</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Iceland</countryName>
+    <countryCode>IS</countryCode>
+    <currencyName>Krona </currencyName>
+    <currencyCode>ISK</currencyCode>
+    <rateNew>179.89</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Indonesia</countryName>
+    <countryCode>ID</countryCode>
+    <currencyName>Rupiah </currencyName>
+    <currencyCode>IDR</currencyCode>
+    <rateNew>19833.08</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Iraq</countryName>
+    <countryCode>IQ</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>IQD</currencyCode>
+    <rateNew>2054.96</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Jamaica</countryName>
+    <countryCode>JM</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>JMD</currencyCode>
+    <rateNew>211.8</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Jordan</countryName>
+    <countryCode>JO</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>JOD</currencyCode>
+    <rateNew>0.9962</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Kazakhstan</countryName>
+    <countryCode>KZ</countryCode>
+    <currencyName>Tenge </currencyName>
+    <currencyCode>KZT</currencyCode>
+    <rateNew>585.83</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Kenya</countryName>
+    <countryCode>KE</countryCode>
+    <currencyName>Schilling </currencyName>
+    <currencyCode>KES</currencyCode>
+    <rateNew>153.99</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Kuwait</countryName>
+    <countryCode>KW</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>KWD</currencyCode>
+    <rateNew>0.425</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Kyrgyz Republic</countryName>
+    <countryCode>KG</countryCode>
+    <currencyName>Som </currencyName>
+    <currencyCode>KGS</currencyCode>
+    <rateNew>118.79</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Lao People's Dem Rep</countryName>
+    <countryCode>LA</countryCode>
+    <currencyName>Kip </currencyName>
+    <currencyCode>LAK</currencyCode>
+    <rateNew>13137.74</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Lebanon</countryName>
+    <countryCode>LB</countryCode>
+    <currencyName>Pound </currencyName>
+    <currencyCode>LBP</currencyCode>
+    <rateNew>2132.24</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Lesotho</countryName>
+    <countryCode>LS</countryCode>
+    <currencyName>Loti </currencyName>
+    <currencyCode>LSL</currencyCode>
+    <rateNew>20.7</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Liberia</countryName>
+    <countryCode>LR</countryCode>
+    <currencyName>Dollar (US) </currencyName>
+    <currencyCode>LRD</currencyCode>
+    <rateNew>1.4051</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Libya</countryName>
+    <countryCode>LY</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>LYD</currencyCode>
+    <rateNew>6.2668</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Macao</countryName>
+    <countryCode>MO</countryCode>
+    <currencyName>Pataca </currencyName>
+    <currencyCode>MOP</currencyCode>
+    <rateNew>11.22</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Macedonia</countryName>
+    <countryCode>MK</countryCode>
+    <currencyName>Denar </currencyName>
+    <currencyCode>MKD</currencyCode>
+    <rateNew>71.28</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Madagascar</countryName>
+    <countryCode>MG</countryCode>
+    <currencyName>Malagasy Ariary</currencyName>
+    <currencyCode>MGA</currencyCode>
+    <rateNew>5290.22</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Malawi</countryName>
+    <countryCode>MW</countryCode>
+    <currencyName>Kwacha </currencyName>
+    <currencyCode>MWK</currencyCode>
+    <rateNew>1094.1</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Maldive Islands</countryName>
+    <countryCode>MV</countryCode>
+    <currencyName>Rufiyaa </currencyName>
+    <currencyCode>MVR</currencyCode>
+    <rateNew>21.63</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Mali Republic</countryName>
+    <countryCode>ML</countryCode>
+    <currencyName>CFA Franc</currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Mauritania</countryName>
+    <countryCode>MR</countryCode>
+    <currencyName>Ouguiya </currencyName>
+    <currencyCode>MRU</currencyCode>
+    <rateNew>50.2</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Mauritius</countryName>
+    <countryCode>MU</countryCode>
+    <currencyName>Rupee </currencyName>
+    <currencyCode>MUR</currencyCode>
+    <rateNew>55.78</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Mexico</countryName>
+    <countryCode>MX</countryCode>
+    <currencyName>Mexican Peso </currencyName>
+    <currencyCode>MXN</currencyCode>
+    <rateNew>29.14</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Moldova</countryName>
+    <countryCode>MD</countryCode>
+    <currencyName>Leu </currencyName>
+    <currencyCode>MDL</currencyCode>
+    <rateNew>24.65</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Mongolia</countryName>
+    <countryCode>MN</countryCode>
+    <currencyName>Tugrik </currencyName>
+    <currencyCode>MNT</currencyCode>
+    <rateNew>4017.9</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Montserrat</countryName>
+    <countryCode>MS</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7938</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Morocco</countryName>
+    <countryCode>MA</countryCode>
+    <currencyName>Dirham </currencyName>
+    <currencyCode>MAD</currencyCode>
+    <rateNew>12.51</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Mozambique</countryName>
+    <countryCode>MZ</countryCode>
+    <currencyName> Metical </currencyName>
+    <currencyCode>MZN</currencyCode>
+    <rateNew>105.52</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Myanmar</countryName>
+    <countryCode>MM</countryCode>
+    <currencyName>Kyat </currencyName>
+    <currencyCode>MMK</currencyCode>
+    <rateNew>1981.21</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Nepal</countryName>
+    <countryCode>NP</countryCode>
+    <currencyName>Rupee </currencyName>
+    <currencyCode>NPR</currencyCode>
+    <rateNew>162.97</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>New Caledonia</countryName>
+    <countryCode>NC</countryCode>
+    <currencyName>CFP Franc </currencyName>
+    <currencyCode>XPF</currencyCode>
+    <rateNew>138.14</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Nicaragua</countryName>
+    <countryCode>NI</countryCode>
+    <currencyName>Gold Cordoba </currencyName>
+    <currencyCode>NIO</currencyCode>
+    <rateNew>49.07</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Niger Republic</countryName>
+    <countryCode>NE</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Nigeria</countryName>
+    <countryCode>NG</countryCode>
+    <currencyName>Naira </currencyName>
+    <currencyCode>NGN</currencyCode>
+    <rateNew>578.55</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Oman</countryName>
+    <countryCode>OM</countryCode>
+    <currencyName>Rial </currencyName>
+    <currencyCode>OMR</currencyCode>
+    <rateNew>0.541</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Pakistan</countryName>
+    <countryCode>PK</countryCode>
+    <currencyName>Rupee </currencyName>
+    <currencyCode>PKR</currencyCode>
+    <rateNew>223.41</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Panama</countryName>
+    <countryCode>PA</countryCode>
+    <currencyName>Balboa </currencyName>
+    <currencyCode>PAB</currencyCode>
+    <rateNew>1.4051</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Papua New Guinea</countryName>
+    <countryCode>PG</countryCode>
+    <currencyName>Kina </currencyName>
+    <currencyCode>PGK</currencyCode>
+    <rateNew>4.9663</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Paraguay</countryName>
+    <countryCode>PY</countryCode>
+    <currencyName>Guarani </currencyName>
+    <currencyCode>PYG</currencyCode>
+    <rateNew>9305.34</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Peru</countryName>
+    <countryCode>PE</countryCode>
+    <currencyName>New Sol </currencyName>
+    <currencyCode>PEN</currencyCode>
+    <rateNew>5.1365</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Philippines</countryName>
+    <countryCode>PH</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>PHP</currencyCode>
+    <rateNew>68.38</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Poland</countryName>
+    <countryCode>PL</countryCode>
+    <currencyName>Zloty </currencyName>
+    <currencyCode>PLN</currencyCode>
+    <rateNew>5.2048</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Qatar</countryName>
+    <countryCode>QA</countryCode>
+    <currencyName>Riyal </currencyName>
+    <currencyCode>QAR</currencyCode>
+    <rateNew>5.116</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Romania</countryName>
+    <countryCode>RO</countryCode>
+    <currencyName>New Leu </currencyName>
+    <currencyCode>RON</currencyCode>
+    <rateNew>5.6445</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Russia</countryName>
+    <countryCode>RU</countryCode>
+    <currencyName>Rouble </currencyName>
+    <currencyCode>RUB</currencyCode>
+    <rateNew>104.49</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Rwanda</countryName>
+    <countryCode>RW</countryCode>
+    <currencyName>Franc </currencyName>
+    <currencyCode>RWF</currencyCode>
+    <rateNew>1380.51</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Saotome &amp; Principe</countryName>
+    <countryCode>ST</countryCode>
+    <currencyName>Dobra </currencyName>
+    <currencyCode>STD</currencyCode>
+    <rateNew>28664.2</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Senegal</countryName>
+    <countryCode>SN</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Serbia</countryName>
+    <countryCode>XS</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>RSD</currencyCode>
+    <rateNew>136.08</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Seychelles</countryName>
+    <countryCode>SC</countryCode>
+    <currencyName>Rupee </currencyName>
+    <currencyCode>SCR</currencyCode>
+    <rateNew>29.92</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Sierra Leone</countryName>
+    <countryCode>SL</countryCode>
+    <currencyName>Leone </currencyName>
+    <currencyCode>SLL</currencyCode>
+    <rateNew>14351.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Soloman Islands</countryName>
+    <countryCode>SB</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>SBD</currencyCode>
+    <rateNew>11.27</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Somali Republic</countryName>
+    <countryCode>SO</countryCode>
+    <currencyName>Schilling </currencyName>
+    <currencyCode>SOS</currencyCode>
+    <rateNew>820.58</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Sri Lanka</countryName>
+    <countryCode>LK</countryCode>
+    <currencyName>Rupee </currencyName>
+    <currencyCode>LKR</currencyCode>
+    <rateNew>271.88</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>St Christopher &amp; Anguilla</countryName>
+    <countryCode>KN</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7938</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>St Lucia</countryName>
+    <countryCode>LC</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7938</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>St Vincent</countryName>
+    <countryCode>VC</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7938</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Sudan Republic</countryName>
+    <countryCode>SD</countryCode>
+    <currencyName>Pound </currencyName>
+    <currencyCode>SDG</currencyCode>
+    <rateNew>77.63</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Surinam</countryName>
+    <countryCode>SR</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>SRD</currencyCode>
+    <rateNew>19.88</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Swaziland</countryName>
+    <countryCode>SZ</countryCode>
+    <currencyName>Lilangeni </currencyName>
+    <currencyCode>SZL</currencyCode>
+    <rateNew>20.7</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Tanzania</countryName>
+    <countryCode>TZ</countryCode>
+    <currencyName>Schilling</currencyName>
+    <currencyCode>TZS</currencyCode>
+    <rateNew>3258.44</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Togo Republic</countryName>
+    <countryCode>TG</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>759.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Tonga Islands</countryName>
+    <countryCode>TO</countryCode>
+    <currencyName>Pa'anga (AUS) </currencyName>
+    <currencyCode>TOP</currencyCode>
+    <rateNew>1.7778</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Trinidad/Tobago</countryName>
+    <countryCode>TT</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>TTD</currencyCode>
+    <rateNew>9.4952</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Tunisia</countryName>
+    <countryCode>TN</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>TND</currencyCode>
+    <rateNew>3.8101</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Turkey</countryName>
+    <countryCode>TR</countryCode>
+    <currencyName>Turkish  Lira </currencyName>
+    <currencyCode>TRY</currencyCode>
+    <rateNew>9.9007</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Turkmenistan</countryName>
+    <countryCode>TM</countryCode>
+    <currencyName>New Manat </currencyName>
+    <currencyCode>TMT</currencyCode>
+    <rateNew>4.9179</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>UAE</countryName>
+    <countryCode>AE</countryCode>
+    <currencyName>Dirham </currencyName>
+    <currencyCode>AED</currencyCode>
+    <rateNew>5.1612</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Uganda</countryName>
+    <countryCode>UG</countryCode>
+    <currencyName>Schilling </currencyName>
+    <currencyCode>UGX</currencyCode>
+    <rateNew>5156.74</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Ukraine</countryName>
+    <countryCode>UA</countryCode>
+    <currencyName>Hryvnia </currencyName>
+    <currencyCode>UAH</currencyCode>
+    <rateNew>39.18</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Uruguay</countryName>
+    <countryCode>UY</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>UYU</currencyCode>
+    <rateNew>60.52</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Uzbekistan</countryName>
+    <countryCode>UZ</countryCode>
+    <currencyName>Sum </currencyName>
+    <currencyCode>UZS</currencyCode>
+    <rateNew>14823.37</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Vanuatu</countryName>
+    <countryCode>VU</countryCode>
+    <currencyName>Vatu </currencyName>
+    <currencyCode>VUV</currencyCode>
+    <rateNew>152.29</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Venezuela</countryName>
+    <countryCode>VE</countryCode>
+    <currencyName>Bolivar Fuerte </currencyName>
+    <currencyCode>VEF</currencyCode>
+    <rateNew>339953</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Vietnam</countryName>
+    <countryCode>VN</countryCode>
+    <currencyName>Dong </currencyName>
+    <currencyCode>VND</currencyCode>
+    <rateNew>32349.05</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Wallis &amp; Futuna Islands</countryName>
+    <countryCode>WF</countryCode>
+    <currencyName>CFP Franc </currencyName>
+    <currencyCode>XPF</currencyCode>
+    <rateNew>138.14</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Western Samoa</countryName>
+    <countryCode>WS</countryCode>
+    <currencyName>Tala </currencyName>
+    <currencyCode>WST</currencyCode>
+    <rateNew>3.5172</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Yemen (Rep of)</countryName>
+    <countryCode>YE</countryCode>
+    <currencyName>Rial </currencyName>
+    <currencyCode>YER</currencyCode>
+    <rateNew>354.84</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Zambia</countryName>
+    <countryCode>ZM</countryCode>
+    <currencyName>Kwacha </currencyName>
+    <currencyCode>ZMW</currencyCode>
+    <rateNew>30.48</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Zimbabwe</countryName>
+    <countryCode>ZW</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>ZWL</currencyCode>
+    <rateNew>508.5</rateNew>
+  </exchangeRate>
+</exchangeRateMonthList>


### PR DESCRIPTION
# PAS-1271

## New feature 

1. Exchange Rate update to March2021 in DEV and PROD.
2. Link to AT >> https://github.com/hmrc/bc-passengers-acceptance-tests/pull/196