### PR TITLE
PAS-811: Exchange Rate update to April 2021 in DEV and PROD

### DIFF
--- a/conf/resources/xml/exrates-monthly-0421.xml
+++ b/conf/resources/xml/exrates-monthly-0421.xml
@@ -1,0 +1,1172 @@
+<?xml version="1.0"?>
+<exchangeRateMonthList Period="01/Apr/2021 to 30/Apr/2021">
+  <exchangeRate>
+    <countryName>Argentina</countryName>
+    <countryCode>AR</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>ARS</currencyCode>
+    <rateNew>125.48</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Australia</countryName>
+    <countryCode>AU</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>AUD</currencyCode>
+    <rateNew>1.8001</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Brazil</countryName>
+    <countryCode>BR</countryCode>
+    <currencyName>Real </currencyName>
+    <currencyCode>BRL</currencyCode>
+    <rateNew>7.6298</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Canada</countryName>
+    <countryCode>CA</countryCode>
+    <currencyName>Dollar</currencyName>
+    <currencyCode>CAD</currencyCode>
+    <rateNew>1.7224</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Denmark</countryName>
+    <countryCode>DK</countryCode>
+    <currencyName>Krone </currencyName>
+    <currencyCode>DKK</currencyCode>
+    <rateNew>8.6242</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Hong Kong</countryName>
+    <countryCode>HK</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>HKD</currencyCode>
+    <rateNew>10.6582</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>India</countryName>
+    <countryCode>IN</countryCode>
+    <currencyName>Rupee </currencyName>
+    <currencyCode>INR</currencyCode>
+    <rateNew>99.56</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Israel</countryName>
+    <countryCode>IL</countryCode>
+    <currencyName>Shekel </currencyName>
+    <currencyCode>ILS</currencyCode>
+    <rateNew>4.5333</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Japan</countryName>
+    <countryCode>JP</countryCode>
+    <currencyName>Yen </currencyName>
+    <currencyCode>JPY</currencyCode>
+    <rateNew>149.3</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Malaysia</countryName>
+    <countryCode>MY</countryCode>
+    <currencyName>Ringgit </currencyName>
+    <currencyCode>MYR</currencyCode>
+    <rateNew>5.6675</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>New Zealand</countryName>
+    <countryCode>NZ</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>NZD</currencyCode>
+    <rateNew>1.9648</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Norway</countryName>
+    <countryCode>NO</countryCode>
+    <currencyName>Norwegian Krone </currencyName>
+    <currencyCode>NOK</currencyCode>
+    <rateNew>11.75</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Saudi Arabia</countryName>
+    <countryCode>SA</countryCode>
+    <currencyName>Riyal </currencyName>
+    <currencyCode>SAR</currencyCode>
+    <rateNew>5.1458</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Singapore</countryName>
+    <countryCode>SG</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>SGD</currencyCode>
+    <rateNew>1.8457</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>South Africa</countryName>
+    <countryCode>ZA</countryCode>
+    <currencyName>Rand </currencyName>
+    <currencyCode>ZAR</currencyCode>
+    <rateNew>20.41</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>South Korea</countryName>
+    <countryCode>KR</countryCode>
+    <currencyName>Won </currencyName>
+    <currencyCode>KRW</currencyCode>
+    <rateNew>1555.54</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Sweden</countryName>
+    <countryCode>SE</countryCode>
+    <currencyName>Krona </currencyName>
+    <currencyCode>SEK</currencyCode>
+    <rateNew>11.79</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Switzerland</countryName>
+    <countryCode>CH</countryCode>
+    <currencyName>Franc </currencyName>
+    <currencyCode>CHF</currencyCode>
+    <rateNew>1.2834</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Taiwan</countryName>
+    <countryCode>TW</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>TWD</currencyCode>
+    <rateNew>39.15</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Thailand</countryName>
+    <countryCode>TH</countryCode>
+    <currencyName>Baht </currencyName>
+    <currencyCode>THB</currencyCode>
+    <rateNew>42.53</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>USA</countryName>
+    <countryCode>US</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>USD</currencyCode>
+    <rateNew>1.3721</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Eurozone</countryName>
+    <countryCode>EU</countryCode>
+    <currencyName>Euro </currencyName>
+    <currencyCode>EUR</currencyCode>
+    <rateNew>1.1598</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Abu Dhabi</countryName>
+    <countryCode>DH</countryCode>
+    <currencyName>Dirham </currencyName>
+    <currencyCode>AED</currencyCode>
+    <rateNew>5.0399</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Albania</countryName>
+    <countryCode>AL</countryCode>
+    <currencyName>Lek </currencyName>
+    <currencyCode>ALL</currencyCode>
+    <rateNew>142.86</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Algeria</countryName>
+    <countryCode>DZ</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>DZD</currencyCode>
+    <rateNew>183.68</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Angola</countryName>
+    <countryCode>AO</countryCode>
+    <currencyName>Readj Kwanza </currencyName>
+    <currencyCode>AOA</currencyCode>
+    <rateNew>859.16</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Antigua</countryName>
+    <countryCode>AG</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7047</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Armenia</countryName>
+    <countryCode>AM</countryCode>
+    <currencyName>Dram </currencyName>
+    <currencyCode>AMD</currencyCode>
+    <rateNew>724.9</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Aruba</countryName>
+    <countryCode>AA</countryCode>
+    <currencyName>Florin</currencyName>
+    <currencyCode>AWG</currencyCode>
+    <rateNew>2.4561</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Azerbaijan</countryName>
+    <countryCode>AZ</countryCode>
+    <currencyName>New Manat </currencyName>
+    <currencyCode>AZN</currencyCode>
+    <rateNew>2.3312</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bahamas</countryName>
+    <countryCode>BS</countryCode>
+    <currencyName>Dollar</currencyName>
+    <currencyCode>BSD</currencyCode>
+    <rateNew>1.3721</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bahrain</countryName>
+    <countryCode>BH</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>BHD</currencyCode>
+    <rateNew>0.5174</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bangladesh</countryName>
+    <countryCode>BD</countryCode>
+    <currencyName>Taka </currencyName>
+    <currencyCode>BDT</currencyCode>
+    <rateNew>116.14</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Barbados</countryName>
+    <countryCode>BB</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>BBD</currencyCode>
+    <rateNew>2.7442</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Belarus</countryName>
+    <countryCode>BY</countryCode>
+    <currencyName>Rouble </currencyName>
+    <currencyCode>BYN</currencyCode>
+    <rateNew>3.6159</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Belize</countryName>
+    <countryCode>BZ</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>BZD</currencyCode>
+    <rateNew>2.7442</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Benin</countryName>
+    <countryCode>BJ</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bermuda</countryName>
+    <countryCode>BM</countryCode>
+    <currencyName>Dollar (US) </currencyName>
+    <currencyCode>BMD</currencyCode>
+    <rateNew>1.3721</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bhutan</countryName>
+    <countryCode>BT</countryCode>
+    <currencyName>Ngultrum </currencyName>
+    <currencyCode>BTN</currencyCode>
+    <rateNew>99.56</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bolivia</countryName>
+    <countryCode>BO</countryCode>
+    <currencyName>Boliviano </currencyName>
+    <currencyCode>BOB</currencyCode>
+    <rateNew>9.4812</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bosnia- Herzegovinia</countryName>
+    <countryCode>BA</countryCode>
+    <currencyName>Marka </currencyName>
+    <currencyCode>BAM</currencyCode>
+    <rateNew>2.2684</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Botswana</countryName>
+    <countryCode>BW</countryCode>
+    <currencyName>Pula </currencyName>
+    <currencyCode>BWP</currencyCode>
+    <rateNew>15.11</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Brunei</countryName>
+    <countryCode>BN</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>BND</currencyCode>
+    <rateNew>1.8457</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Bulgaria</countryName>
+    <countryCode>BG</countryCode>
+    <currencyName>Lev </currencyName>
+    <currencyCode>BGN</currencyCode>
+    <rateNew>2.2684</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Burkina Faso</countryName>
+    <countryCode>BK</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Burundi</countryName>
+    <countryCode>BI</countryCode>
+    <currencyName>Franc </currencyName>
+    <currencyCode>BIF</currencyCode>
+    <rateNew>2682.01</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Cambodia</countryName>
+    <countryCode>KH</countryCode>
+    <currencyName>Riel </currencyName>
+    <currencyCode>KHR</currencyCode>
+    <rateNew>5559.74</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Cameroon Republic</countryName>
+    <countryCode>CM</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XAF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Cape Verde Islands</countryName>
+    <countryCode>CV</countryCode>
+    <currencyName>Escudo </currencyName>
+    <currencyCode>CVE</currencyCode>
+    <rateNew>128.41</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Cayman Islands</countryName>
+    <countryCode>KY</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>KYD</currencyCode>
+    <rateNew>1.1251</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Central African Republic</countryName>
+    <countryCode>CF</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XAF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Chad</countryName>
+    <countryCode>TD</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XAF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Chile</countryName>
+    <countryCode>CL</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>CLP</currencyCode>
+    <rateNew>999.27</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>China</countryName>
+    <countryCode>CN</countryCode>
+    <currencyName>Yuan</currencyName>
+    <currencyCode>CNY</currencyCode>
+    <rateNew>8.9505</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Colombia</countryName>
+    <countryCode>CO</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>COP</currencyCode>
+    <rateNew>4994.47</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Comoros</countryName>
+    <countryCode>KM</countryCode>
+    <currencyName>Franc </currencyName>
+    <currencyCode>KMF</currencyCode>
+    <rateNew>570.58</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Congo (Brazaville)</countryName>
+    <countryCode>CG</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XAF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Congo (DemRep)</countryName>
+    <countryCode>ZR</countryCode>
+    <currencyName>Congo Fr </currencyName>
+    <currencyCode>CDF</currencyCode>
+    <rateNew>2696.03</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Costa Rica</countryName>
+    <countryCode>CR</countryCode>
+    <currencyName>Colon </currencyName>
+    <currencyCode>CRC</currencyCode>
+    <rateNew>838.62</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Cote d'Ivoire</countryName>
+    <countryCode>CI</countryCode>
+    <currencyName>CFA Franc</currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Croatia</countryName>
+    <countryCode>HR</countryCode>
+    <currencyName>Kuna </currencyName>
+    <currencyCode>HRK</currencyCode>
+    <rateNew>8.7851</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Cuba</countryName>
+    <countryCode>CU</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>CUP</currencyCode>
+    <rateNew>1.3721</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Czech Republic</countryName>
+    <countryCode>CZ</countryCode>
+    <currencyName>Koruna </currencyName>
+    <currencyCode>CZK</currencyCode>
+    <rateNew>30.44</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Djibouti</countryName>
+    <countryCode>DJ</countryCode>
+    <currencyName>Franc </currencyName>
+    <currencyCode>DJF</currencyCode>
+    <rateNew>243.84</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Dominica</countryName>
+    <countryCode>DM</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7047</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Dominican Republic</countryName>
+    <countryCode>DO</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>DOP</currencyCode>
+    <rateNew>78.34</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Dubai</countryName>
+    <countryCode>DU</countryCode>
+    <currencyName>Dirham </currencyName>
+    <currencyCode>AED</currencyCode>
+    <rateNew>5.0399</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Ecuador</countryName>
+    <countryCode>EC</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>ECS</currencyCode>
+    <rateNew>1.3721</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Egypt</countryName>
+    <countryCode>EG</countryCode>
+    <currencyName>Pound </currencyName>
+    <currencyCode>EGP</currencyCode>
+    <rateNew>21.62</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>El Salvador</countryName>
+    <countryCode>SV</countryCode>
+    <currencyName>Colon </currencyName>
+    <currencyCode>SVC</currencyCode>
+    <rateNew>12</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Equatorial Guinea</countryName>
+    <countryCode>GQ</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XAF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Eritrea</countryName>
+    <countryCode>ER</countryCode>
+    <currencyName>Nakfa </currencyName>
+    <currencyCode>ERN</currencyCode>
+    <rateNew>20.58</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Ethiopia</countryName>
+    <countryCode>ET</countryCode>
+    <currencyName>Birr </currencyName>
+    <currencyCode>ETB</currencyCode>
+    <rateNew>55.44</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Fiji Islands</countryName>
+    <countryCode>FJ</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>FJD</currencyCode>
+    <rateNew>2.8352</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Fr. Polynesia</countryName>
+    <countryCode>PF</countryCode>
+    <currencyName>CFP Franc</currencyName>
+    <currencyCode>XPF</currencyCode>
+    <rateNew>138.4</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Gabon</countryName>
+    <countryCode>GA</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XAF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Gambia</countryName>
+    <countryCode>GM</countryCode>
+    <currencyName>Dalasi </currencyName>
+    <currencyCode>GMD</currencyCode>
+    <rateNew>70.32</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Georgia</countryName>
+    <countryCode>GE</countryCode>
+    <currencyName>Lari </currencyName>
+    <currencyCode>GEL</currencyCode>
+    <rateNew>4.5828</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Ghana</countryName>
+    <countryCode>GH</countryCode>
+    <currencyName>Cedi </currencyName>
+    <currencyCode>GHS</currencyCode>
+    <rateNew>7.8896</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Grenada</countryName>
+    <countryCode>GD</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7047</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Guatemala</countryName>
+    <countryCode>GT</countryCode>
+    <currencyName>Quetzal </currencyName>
+    <currencyCode>GTQ</currencyCode>
+    <rateNew>10.6</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Guinea Bissau</countryName>
+    <countryCode>GW</countryCode>
+    <currencyName>CFA Franc</currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Guinea Republic</countryName>
+    <countryCode>GN</countryCode>
+    <currencyName>Franc </currencyName>
+    <currencyCode>GNF</currencyCode>
+    <rateNew>13762.16</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Guyana</countryName>
+    <countryCode>GY</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>GYD</currencyCode>
+    <rateNew>287.93</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Haiti</countryName>
+    <countryCode>HT</countryCode>
+    <currencyName>Gourde </currencyName>
+    <currencyCode>HTG</currencyCode>
+    <rateNew>107.51</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Honduras</countryName>
+    <countryCode>HN</countryCode>
+    <currencyName>Lempira </currencyName>
+    <currencyCode>HNL</currencyCode>
+    <rateNew>32.95</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Hungary</countryName>
+    <countryCode>HU</countryCode>
+    <currencyName>Forint </currencyName>
+    <currencyCode>HUF</currencyCode>
+    <rateNew>423.15</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Iceland</countryName>
+    <countryCode>IS</countryCode>
+    <currencyName>Krona </currencyName>
+    <currencyCode>ISK</currencyCode>
+    <rateNew>173.61</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Indonesia</countryName>
+    <countryCode>ID</countryCode>
+    <currencyName>Rupiah </currencyName>
+    <currencyCode>IDR</currencyCode>
+    <rateNew>19792.57</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Iraq</countryName>
+    <countryCode>IQ</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>IQD</currencyCode>
+    <rateNew>2006.69</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Jamaica</countryName>
+    <countryCode>JM</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>JMD</currencyCode>
+    <rateNew>199.63</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Jordan</countryName>
+    <countryCode>JO</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>JOD</currencyCode>
+    <rateNew>0.9728</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Kazakhstan</countryName>
+    <countryCode>KZ</countryCode>
+    <currencyName>Tenge </currencyName>
+    <currencyCode>KZT</currencyCode>
+    <rateNew>577.25</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Kenya</countryName>
+    <countryCode>KE</countryCode>
+    <currencyName>Schilling </currencyName>
+    <currencyCode>KES</currencyCode>
+    <rateNew>150.65</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Kuwait</countryName>
+    <countryCode>KW</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>KWD</currencyCode>
+    <rateNew>0.4145</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Kyrgyz Republic</countryName>
+    <countryCode>KG</countryCode>
+    <currencyName>Som </currencyName>
+    <currencyCode>KGS</currencyCode>
+    <rateNew>116.35</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Lao People's Dem Rep</countryName>
+    <countryCode>LA</countryCode>
+    <currencyName>Kip </currencyName>
+    <currencyCode>LAK</currencyCode>
+    <rateNew>12890.87</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Lebanon</countryName>
+    <countryCode>LB</countryCode>
+    <currencyName>Pound </currencyName>
+    <currencyCode>LBP</currencyCode>
+    <rateNew>2083.39</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Lesotho</countryName>
+    <countryCode>LS</countryCode>
+    <currencyName>Loti </currencyName>
+    <currencyCode>LSL</currencyCode>
+    <rateNew>20.41</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Liberia</countryName>
+    <countryCode>LR</countryCode>
+    <currencyName>Dollar (US) </currencyName>
+    <currencyCode>LRD</currencyCode>
+    <rateNew>1.3721</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Libya</countryName>
+    <countryCode>LY</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>LYD</currencyCode>
+    <rateNew>6.1744</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Macao</countryName>
+    <countryCode>MO</countryCode>
+    <currencyName>Pataca </currencyName>
+    <currencyCode>MOP</currencyCode>
+    <rateNew>10.97</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Macedonia</countryName>
+    <countryCode>MK</countryCode>
+    <currencyName>Denar </currencyName>
+    <currencyCode>MKD</currencyCode>
+    <rateNew>71.41</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Madagascar</countryName>
+    <countryCode>MG</countryCode>
+    <currencyName>Malagasy Ariary</currencyName>
+    <currencyCode>MGA</currencyCode>
+    <rateNew>5186.53</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Malawi</countryName>
+    <countryCode>MW</countryCode>
+    <currencyName>Kwacha </currencyName>
+    <currencyCode>MWK</currencyCode>
+    <rateNew>1074.75</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Maldive Islands</countryName>
+    <countryCode>MV</countryCode>
+    <currencyName>Rufiyaa </currencyName>
+    <currencyCode>MVR</currencyCode>
+    <rateNew>21.19</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Mali Republic</countryName>
+    <countryCode>ML</countryCode>
+    <currencyName>CFA Franc</currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Mauritania</countryName>
+    <countryCode>MR</countryCode>
+    <currencyName>Ouguiya </currencyName>
+    <currencyCode>MRU</currencyCode>
+    <rateNew>49.02</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Mauritius</countryName>
+    <countryCode>MU</countryCode>
+    <currencyName>Rupee </currencyName>
+    <currencyCode>MUR</currencyCode>
+    <rateNew>55.29</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Mexico</countryName>
+    <countryCode>MX</countryCode>
+    <currencyName>Mexican Peso </currencyName>
+    <currencyCode>MXN</currencyCode>
+    <rateNew>28.54</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Moldova</countryName>
+    <countryCode>MD</countryCode>
+    <currencyName>Leu </currencyName>
+    <currencyCode>MDL</currencyCode>
+    <rateNew>24.54</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Mongolia</countryName>
+    <countryCode>MN</countryCode>
+    <currencyName>Tugrik </currencyName>
+    <currencyCode>MNT</currencyCode>
+    <rateNew>3917.34</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Montserrat</countryName>
+    <countryCode>MS</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7047</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Morocco</countryName>
+    <countryCode>MA</countryCode>
+    <currencyName>Dirham </currencyName>
+    <currencyCode>MAD</currencyCode>
+    <rateNew>12.38</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Mozambique</countryName>
+    <countryCode>MZ</countryCode>
+    <currencyName> Metical </currencyName>
+    <currencyCode>MZN</currencyCode>
+    <rateNew>98.92</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Myanmar</countryName>
+    <countryCode>MM</countryCode>
+    <currencyName>Kyat </currencyName>
+    <currencyCode>MMK</currencyCode>
+    <rateNew>1934.97</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Nepal</countryName>
+    <countryCode>NP</countryCode>
+    <currencyName>Rupee </currencyName>
+    <currencyCode>NPR</currencyCode>
+    <rateNew>159.3</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>New Caledonia</countryName>
+    <countryCode>NC</countryCode>
+    <currencyName>CFP Franc </currencyName>
+    <currencyCode>XPF</currencyCode>
+    <rateNew>138.4</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Nicaragua</countryName>
+    <countryCode>NI</countryCode>
+    <currencyName>Gold Cordoba </currencyName>
+    <currencyCode>NIO</currencyCode>
+    <rateNew>47.99</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Niger Republic</countryName>
+    <countryCode>NE</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Nigeria</countryName>
+    <countryCode>NG</countryCode>
+    <currencyName>Naira </currencyName>
+    <currencyCode>NGN</currencyCode>
+    <rateNew>561.84</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Oman</countryName>
+    <countryCode>OM</countryCode>
+    <currencyName>Rial </currencyName>
+    <currencyCode>OMR</currencyCode>
+    <rateNew>0.5283</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Pakistan</countryName>
+    <countryCode>PK</countryCode>
+    <currencyName>Rupee </currencyName>
+    <currencyCode>PKR</currencyCode>
+    <rateNew>213.08</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Panama</countryName>
+    <countryCode>PA</countryCode>
+    <currencyName>Balboa </currencyName>
+    <currencyCode>PAB</currencyCode>
+    <rateNew>1.3721</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Papua New Guinea</countryName>
+    <countryCode>PG</countryCode>
+    <currencyName>Kina </currencyName>
+    <currencyCode>PGK</currencyCode>
+    <rateNew>4.8187</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Paraguay</countryName>
+    <countryCode>PY</countryCode>
+    <currencyName>Guarani </currencyName>
+    <currencyCode>PYG</currencyCode>
+    <rateNew>8902.8</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Peru</countryName>
+    <countryCode>PE</countryCode>
+    <currencyName>New Sol </currencyName>
+    <currencyCode>PEN</currencyCode>
+    <rateNew>5.1074</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Philippines</countryName>
+    <countryCode>PH</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>PHP</currencyCode>
+    <rateNew>66.79</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Poland</countryName>
+    <countryCode>PL</countryCode>
+    <currencyName>Zloty </currencyName>
+    <currencyCode>PLN</currencyCode>
+    <rateNew>5.3659</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Qatar</countryName>
+    <countryCode>QA</countryCode>
+    <currencyName>Riyal </currencyName>
+    <currencyCode>QAR</currencyCode>
+    <rateNew>4.9958</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Romania</countryName>
+    <countryCode>RO</countryCode>
+    <currencyName>New Leu </currencyName>
+    <currencyCode>RON</currencyCode>
+    <rateNew>5.6688</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Russia</countryName>
+    <countryCode>RU</countryCode>
+    <currencyName>Rouble </currencyName>
+    <currencyCode>RUB</currencyCode>
+    <rateNew>104.9</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Rwanda</countryName>
+    <countryCode>RW</countryCode>
+    <currencyName>Franc </currencyName>
+    <currencyCode>RWF</currencyCode>
+    <rateNew>1353.32</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Saotome &amp; Principe</countryName>
+    <countryCode>ST</countryCode>
+    <currencyName>Dobra </currencyName>
+    <currencyCode>STD</currencyCode>
+    <rateNew>28608.3</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Senegal</countryName>
+    <countryCode>SN</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Serbia</countryName>
+    <countryCode>XS</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>RSD</currencyCode>
+    <rateNew>136.35</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Seychelles</countryName>
+    <countryCode>SC</countryCode>
+    <currencyName>Rupee </currencyName>
+    <currencyCode>SCR</currencyCode>
+    <rateNew>29.14</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Sierra Leone</countryName>
+    <countryCode>SL</countryCode>
+    <currencyName>Leone </currencyName>
+    <currencyCode>SLL</currencyCode>
+    <rateNew>14022.86</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Soloman Islands</countryName>
+    <countryCode>SB</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>SBD</currencyCode>
+    <rateNew>10.95</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Somali Republic</countryName>
+    <countryCode>SO</countryCode>
+    <currencyName>Schilling </currencyName>
+    <currencyCode>SOS</currencyCode>
+    <rateNew>802.67</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Sri Lanka</countryName>
+    <countryCode>LK</countryCode>
+    <currencyName>Rupee </currencyName>
+    <currencyCode>LKR</currencyCode>
+    <rateNew>273.04</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>St Christopher &amp; Anguilla</countryName>
+    <countryCode>KN</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7047</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>St Lucia</countryName>
+    <countryCode>LC</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7047</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>St Vincent</countryName>
+    <countryCode>VC</countryCode>
+    <currencyName>E Caribbean Dollar </currencyName>
+    <currencyCode>XCD</currencyCode>
+    <rateNew>3.7047</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Sudan Republic</countryName>
+    <countryCode>SD</countryCode>
+    <currencyName>Pound </currencyName>
+    <currencyCode>SDG</currencyCode>
+    <rateNew>70.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Surinam</countryName>
+    <countryCode>SR</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>SRD</currencyCode>
+    <rateNew>19.42</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Swaziland</countryName>
+    <countryCode>SZ</countryCode>
+    <currencyName>Lilangeni </currencyName>
+    <currencyCode>SZL</currencyCode>
+    <rateNew>20.41</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Tanzania</countryName>
+    <countryCode>TZ</countryCode>
+    <currencyName>Schilling</currencyName>
+    <currencyCode>TZS</currencyCode>
+    <rateNew>3181.89</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Togo Republic</countryName>
+    <countryCode>TG</countryCode>
+    <currencyName>CFA Franc </currencyName>
+    <currencyCode>XOF</currencyCode>
+    <rateNew>760.77</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Tonga Islands</countryName>
+    <countryCode>TO</countryCode>
+    <currencyName>Pa'anga (AUS) </currencyName>
+    <currencyCode>TOP</currencyCode>
+    <rateNew>1.3119</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Trinidad/Tobago</countryName>
+    <countryCode>TT</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>TTD</currencyCode>
+    <rateNew>9.3015</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Tunisia</countryName>
+    <countryCode>TN</countryCode>
+    <currencyName>Dinar </currencyName>
+    <currencyCode>TND</currencyCode>
+    <rateNew>3.8144</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Turkey</countryName>
+    <countryCode>TR</countryCode>
+    <currencyName>Turkish  Lira </currencyName>
+    <currencyCode>TRY</currencyCode>
+    <rateNew>10.86</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Turkmenistan</countryName>
+    <countryCode>TM</countryCode>
+    <currencyName>New Manat </currencyName>
+    <currencyCode>TMT</currencyCode>
+    <rateNew>4.8161</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>UAE</countryName>
+    <countryCode>AE</countryCode>
+    <currencyName>Dirham </currencyName>
+    <currencyCode>AED</currencyCode>
+    <rateNew>5.0399</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Uganda</countryName>
+    <countryCode>UG</countryCode>
+    <currencyName>Schilling </currencyName>
+    <currencyCode>UGX</currencyCode>
+    <rateNew>5028.74</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Ukraine</countryName>
+    <countryCode>UA</countryCode>
+    <currencyName>Hryvnia </currencyName>
+    <currencyCode>UAH</currencyCode>
+    <rateNew>38.36</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Uruguay</countryName>
+    <countryCode>UY</countryCode>
+    <currencyName>Peso </currencyName>
+    <currencyCode>UYU</currencyCode>
+    <rateNew>60.73</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Uzbekistan</countryName>
+    <countryCode>UZ</countryCode>
+    <currencyName>Sum </currencyName>
+    <currencyCode>UZS</currencyCode>
+    <rateNew>14417.59</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Vanuatu</countryName>
+    <countryCode>VU</countryCode>
+    <currencyName>Vatu </currencyName>
+    <currencyCode>VUV</currencyCode>
+    <rateNew>149.33</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Venezuela</countryName>
+    <countryCode>VE</countryCode>
+    <currencyName>Bolivar Fuerte </currencyName>
+    <currencyCode>VEF</currencyCode>
+    <rateNew>337216.34</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Vietnam</countryName>
+    <countryCode>VN</countryCode>
+    <currencyName>Dong </currencyName>
+    <currencyCode>VND</currencyCode>
+    <rateNew>31671.52</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Wallis &amp; Futuna Islands</countryName>
+    <countryCode>WF</countryCode>
+    <currencyName>CFP Franc </currencyName>
+    <currencyCode>XPF</currencyCode>
+    <rateNew>138.4</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Western Samoa</countryName>
+    <countryCode>WS</countryCode>
+    <currencyName>Tala </currencyName>
+    <currencyCode>WST</currencyCode>
+    <rateNew>3.4781</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Yemen (Rep of)</countryName>
+    <countryCode>YE</countryCode>
+    <currencyName>Rial </currencyName>
+    <currencyCode>YER</currencyCode>
+    <rateNew>346.93</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Zambia</countryName>
+    <countryCode>ZM</countryCode>
+    <currencyName>Kwacha </currencyName>
+    <currencyCode>ZMW</currencyCode>
+    <rateNew>30.22</rateNew>
+  </exchangeRate>
+  <exchangeRate>
+    <countryName>Zimbabwe</countryName>
+    <countryCode>ZW</countryCode>
+    <currencyName>Dollar </currencyName>
+    <currencyCode>ZWL</currencyCode>
+    <rateNew>496.56</rateNew>
+  </exchangeRate>
+</exchangeRateMonthList>


### PR DESCRIPTION
# PAS-811

## New feature 

1. Exchange Rate update to April2021 in DEV and PROD.
2. Link to AT >> https://github.com/hmrc/bc-passengers-acceptance-tests/pull/207