### PR TITLE
DDCE-3135 - Currency Conversion Fix

### DIFF
--- a/app/uk/gov/hmrc/currencyconversion/repositories/ConversionRatePeriodJson.scala
+++ b/app/uk/gov/hmrc/currencyconversion/repositories/ConversionRatePeriodJson.scala
@@ -17,16 +17,14 @@
 package uk.gov.hmrc.currencyconversion.repositories
 
 import akka.stream.Materializer
+import play.api.i18n.Lang.logger.logger
 import play.api.libs.json.JsSuccess
+import play.api.libs.json.OFormat.oFormatFromReadsAndOWrites
 import uk.gov.hmrc.currencyconversion.models.{ConversionRatePeriod, Currency, CurrencyPeriod, ExchangeRateData}
 
 import java.time.LocalDate
-import play.api.i18n.Lang.logger.logger
 import javax.inject.Inject
-import play.api.libs.json.OFormat.oFormatFromReadsAndOWrites
-
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 
 
@@ -37,7 +35,7 @@ class ConversionRatePeriodJson @Inject()(writeExchangeRateRepository: ExchangeRa
     val targetFileName = "exrates-monthly-%02d".format(date.getMonthValue) +
       date.getYear.toString.substring(2)
 
-    if (!writeExchangeRateRepository.isDataPresent(targetFileName)) {
+    if (writeExchangeRateRepository.isDataPresent(targetFileName)) {
       targetFileName
     } else {
       logger.info(s"$targetFileName is not present")

--- a/app/uk/gov/hmrc/currencyconversion/workers/XrsExchangeRateRequestWorker.scala
+++ b/app/uk/gov/hmrc/currencyconversion/workers/XrsExchangeRateRequestWorker.scala
@@ -29,11 +29,13 @@ import uk.gov.hmrc.currencyconversion.repositories.ExchangeRateRepository
 import uk.gov.hmrc.http.HttpReads.{is2xx, is4xx}
 import uk.gov.hmrc.http.HttpResponse
 
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters._
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Try}
 import scala.util.control.Exception._
 import scala.util.control.NonFatal
+import scala.util.{Failure, Try}
 
 @Singleton
 class XrsExchangeRateRequestWorker @Inject()(
@@ -41,7 +43,7 @@ class XrsExchangeRateRequestWorker @Inject()(
                                               hodConnector: HODConnector,
                                               writeExchangeRateRepository: ExchangeRateRepository,
                                               xrsDelayHelper: XrsDelayHelper
-                                            )(implicit mat: Materializer, ec: ExecutionContext) {
+                                            )(implicit mat: Materializer, ec: ExecutionContext) extends XrsExchangeRateRequest {
 
   private val initialDelayFromConfig = config.get[String]("workers.xrs-exchange-rate.initial-delay").replace('.', ' ')
   private val parallelism = config.get[String]("workers.xrs-exchange-rate.parallelism").replace('.', ' ')
@@ -52,9 +54,9 @@ class XrsExchangeRateRequestWorker @Inject()(
 
   private val intervalFromConfig = config.get[String]("workers.xrs-exchange-rate.interval").replace('.', ' ')
   private val intervalFromConfigFiniteDuration = config.get[FiniteDuration]("workers.xrs-exchange-rate.interval")
+  override protected val daysBeforeNextMonthToAlertForNextMonthsFile: Int = config.get[Int]("workers.xrs-exchange-rate.next-month-alert-days")
   private val finiteInterval = Duration(intervalFromConfig)
   private val interval = Some(finiteInterval).collect { case d: FiniteDuration => d }.getOrElse(intervalFromConfigFiniteDuration)
-
 
   private val supervisionStrategy: Supervision.Decider = {
     case NonFatal(_) => Supervision.resume
@@ -65,7 +67,7 @@ class XrsExchangeRateRequestWorker @Inject()(
     Source.tick(xrsDelayHelper.calculateInitialDelay(scheduledTime, initialDelay), interval, Tick())
       .mapAsync(allCatch.opt(parallelism.toInt).getOrElse(1)) {
         _ =>
-          hodConnector.submit().flatMap {
+          val response = hodConnector.submit().flatMap {
             case response: HttpResponse if is2xx(response.status) =>
               successfulResponse(response)
             case response: HttpResponse if is4xx(response.status) =>
@@ -74,6 +76,10 @@ class XrsExchangeRateRequestWorker @Inject()(
             case _ => logger.error(s"XRS_BAD_REQUEST_FROM_EIS_ERROR [XrsExchangeRateRequestWorker] BAD Request is received from DES (EIS)")
               Future.successful(HttpResponse(SERVICE_UNAVAILABLE, "Service Unavailable"))
           }
+          if (checkNextMonthsFileIsReceivedDaysBeforeEndOfMonth) {
+            isNextMonthsFileIsReceived(writeExchangeRateRepository)
+          }
+          response
       }
       .wireTapMat(Sink.queue())(Keep.right)
       .toMat(Sink.ignore)(Keep.left)
@@ -84,8 +90,10 @@ class XrsExchangeRateRequestWorker @Inject()(
   private def successfulResponse(response: HttpResponse) = {
     getResponseJson(response).map {
       exchangeRatesJson =>
-        logExchangeDataSize(exchangeRatesJson)
-        writeExchangeRateRepository.insertOrUpdate(exchangeRatesJson)
+        val triedData = Try(exchangeRatesJson.as[ExchangeRateData])
+        if (verifyExchangeDataIsNotEmpty(triedData) && triedData.isSuccess) {
+          writeExchangeRateRepository.insertOrUpdate(exchangeRatesJson, areRatesForNextMonth(triedData.get))
+        }
     }
     Future.successful(response)
   }
@@ -100,17 +108,64 @@ class XrsExchangeRateRequestWorker @Inject()(
     }
   }
 
-  private def logExchangeDataSize(exchangeRatesJson: JsObject): Unit = {
-    Try {
-      val tps = exchangeRatesJson.as[ExchangeRateData]
-      if (tps.exchangeData.isEmpty) {
-        logger.warn("[XrsExchangeRateRequestWorker] [logExchangeDataSize] Exchange Data size is 0")
+  private def verifyExchangeDataIsNotEmpty(exchangeRateDataTry: Try[ExchangeRateData]): Boolean = {
+    exchangeRateDataTry.map { exchangeRateData =>
+      if (exchangeRateData.exchangeData.isEmpty) {
+        logger.error("XRS_EMPTY_RATES_FILE_ERROR [XrsExchangeRateRequestWorker] [verifyExchangeDataIsNotEmpty] Exchange Data size is 0")
       } else {
-        logger.info(s"[XrsExchangeRateRequestWorker] [logExchangeDataSize] Exchange Data size is ${tps.exchangeData.size}")
+        logger.info(s"[XrsExchangeRateRequestWorker] [verifyExchangeDataIsNotEmpty] " +
+          s"Exchange Data size is ${exchangeRateData.exchangeData.size} with timestamp ${exchangeRateData.timestamp}")
       }
+      exchangeRateData.exchangeData.isEmpty
     } getOrElse {
-      logger.error("[XrsExchangeRateRequestWorker] [logExchangeDataSize] Cannot convert response JSON to ExchangeRateData")
+      logger.error("XRS_RATES_FILE_INVALID_FORMAT [XrsExchangeRateRequestWorker] [verifyExchangeDataIsNotEmpty] " +
+        "Cannot convert response JSON to ExchangeRateData")
+      false
     }
+  }
+
+
+}
+
+trait XrsExchangeRateRequest {
+
+  private[workers] def now: LocalDate = LocalDate.now
+  protected val daysBeforeNextMonthToAlertForNextMonthsFile: Int = 5
+
+  private[workers] def checkNextMonthsFileIsReceivedDaysBeforeEndOfMonth = {
+    now.plusDays(daysBeforeNextMonthToAlertForNextMonthsFile).getMonthValue != now.getMonthValue
+  }
+
+  private[workers] def areRatesForNextMonth(exchangeRateData: ExchangeRateData): Boolean = {
+
+    val totalRates = exchangeRateData.exchangeData.size
+    val nextMonthsRates = exchangeRateData.exchangeData.count(ed => ed.validFrom.isAfter(now.`with`(lastDayOfMonth())))
+    val expiredRates = exchangeRateData.exchangeData.count(ed => ed.validTo.isBefore(now))
+
+    logger.info(s"[XrsExchangeRateRequest][areRatesForNextMonth] " +
+      s"total rates=$totalRates, next months rates=$nextMonthsRates, expired rates=$expiredRates")
+
+    if (nextMonthsRates > 0 && totalRates != nextMonthsRates) {
+      logger.error(s"XRS_FILE_HAS_MIXED_MONTHS_ERROR [XrsExchangeRateRequest][areRatesForNextMonth] Exchange rates file has a mixture of months. " +
+        s"Total rates=$totalRates, next months rates=$nextMonthsRates, expired rates=$expiredRates.")
+    }
+
+    if (totalRates == nextMonthsRates) {
+      logger.error("XRS_FILE_DETECTED_FOR_NEXT_MONTH [XrsExchangeRateRequest][areRatesForNextMonth] Inserting XRS file for next month")
+    }
+    totalRates == nextMonthsRates
+  }
+
+  private[workers] def isNextMonthsFileIsReceived(writeExchangeRateRepository: ExchangeRateRepository): Boolean = {
+    val targetFileName = "exrates-monthly-%02d".format(now.plusMonths(1).getMonthValue) +
+      now.plusMonths(1).getYear.toString.substring(2)
+    val isNextMonthsDataPresent = writeExchangeRateRepository.isDataPresent(targetFileName)
+    if (isNextMonthsDataPresent) {
+      logger.info(s"[XrsExchangeRateRequest] [verifyIfNextMonthsFileIsReceived] $targetFileName exists")
+    } else {
+      logger.error(s"XRS_FILE_NEXT_MONTH_NOT_RECEIVED [XrsExchangeRateRequest] [verifyIfNextMonthsFileIsReceived] $targetFileName")
+    }
+    isNextMonthsDataPresent
   }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -69,7 +69,7 @@ application.session.secure=false
 
 # The application languages
 # ~~~~~
-application.langs="en"
+play.i18n.langs=["en"]
 
 # Router
 # ~~~~~
@@ -153,6 +153,7 @@ workers {
     interval      = 1.minutes
     parallelism   = 1
     scheduled-time= false
+    next-month-alert-days = 5
   }
 }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     ws,
     "uk.gov.hmrc"        %% "bootstrap-backend-play-28" % "5.24.0",
-    "uk.gov.hmrc.mongo"  %% "hmrc-mongo-play-28"        % "0.64.0",
+    "uk.gov.hmrc.mongo"  %% "hmrc-mongo-play-28"        % "0.65.0",
     "org.reactivemongo"  %% "reactivemongo-akkastream"  % "1.0.10"
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.3.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 

--- a/test/uk/gov/hmrc/currencyconversion/controllers/ExchangeRateControllerSpec.scala
+++ b/test/uk/gov/hmrc/currencyconversion/controllers/ExchangeRateControllerSpec.scala
@@ -49,7 +49,7 @@ class ExchangeRateControllerSpec extends AnyWordSpecLike with GuiceOneAppPerSuit
   override def beforeEach(): Unit = {
     Mockito.reset(exchangeRateRepository)
     val exchangeRate : ExchangeRateObject = ExchangeRateObject("exrates-monthly-0919", Json.parse(data).as[JsObject])
-    doReturn(false) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
+    doReturn(true) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
     doReturn(successful(Some(exchangeRate))) when exchangeRateRepository get "exrates-monthly-0919"
 
     SharedMetricRegistries.clear()
@@ -160,7 +160,7 @@ class ExchangeRateControllerSpec extends AnyWordSpecLike with GuiceOneAppPerSuit
      "Getting rates for a date which has no rates Json file and a valid currency code" must {
 
        "return 200 and the correct json" in {
-         doReturn(true) when exchangeRateRepository isDataPresent "exrates-monthly-1019"
+         doReturn(false) when exchangeRateRepository isDataPresent "exrates-monthly-1019"
 
          val result = route(app, FakeRequest("GET", "/currency-conversion/rates/2019-10-10?cc=USD")).get
 
@@ -172,7 +172,7 @@ class ExchangeRateControllerSpec extends AnyWordSpecLike with GuiceOneAppPerSuit
 
      "Getting rates for a date which has no rates Json file, 1 valid currency code and 1 invalid currency code" must {
        "return response from previous month" in {
-         doReturn(true) when exchangeRateRepository isDataPresent "exrates-monthly-1019"
+         doReturn(false) when exchangeRateRepository isDataPresent "exrates-monthly-1019"
          val result = route(app, FakeRequest("GET", "/currency-conversion/rates/2019-10-10?cc=USD&cc=INVALID")).get
 
          status(result) shouldBe Status.OK
@@ -225,7 +225,7 @@ class ExchangeRateControllerSpec extends AnyWordSpecLike with GuiceOneAppPerSuit
        "return 200 and the correct json" in {
 
          val exchangeRate : ExchangeRateObject = ExchangeRateObject("exrates-monthly-0919", Json.parse(data).as[JsObject])
-         doReturn(false) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
+         doReturn(true) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
          doReturn(successful(Some(exchangeRate))) when exchangeRateRepository get "exrates-monthly-0919"
 
          val result = route(app, FakeRequest("GET", "/currency-conversion/currencies/2019-09-01")).get
@@ -251,7 +251,7 @@ class ExchangeRateControllerSpec extends AnyWordSpecLike with GuiceOneAppPerSuit
        "return 200 if fallback is available" in {
 
          val exchangeRate : ExchangeRateObject = ExchangeRateObject("exrates-monthly-0919", Json.parse(data).as[JsObject])
-         doReturn(false) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
+         doReturn(true) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
          doReturn(successful(Some(exchangeRate))) when exchangeRateRepository get "exrates-monthly-0919"
 
 

--- a/test/uk/gov/hmrc/currencyconversion/workers/XrsExchangeRateRequestWorkerSpec.scala
+++ b/test/uk/gov/hmrc/currencyconversion/workers/XrsExchangeRateRequestWorkerSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.currencyconversion.workers
 
 
 import com.github.tomakehurst.wiremock.client.WireMock._
+import org.mockito.Mockito.doReturn
 import org.scalatest.OptionValues
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
@@ -25,7 +26,12 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers._
+import uk.gov.hmrc.currencyconversion.models.{ExchangeRate, ExchangeRateData}
+import uk.gov.hmrc.currencyconversion.repositories.ExchangeRateRepository
 import uk.gov.hmrc.currencyconversion.utils.WireMockHelper
+
+import java.time.LocalDate
+import scala.language.postfixOps
 
 class XrsExchangeRateRequestWorkerSpec extends AnyWordSpec with Matchers
   with ScalaFutures with IntegrationPatience with OptionValues with MockitoSugar with WireMockHelper with Eventually {
@@ -47,6 +53,11 @@ class XrsExchangeRateRequestWorkerSpec extends AnyWordSpec with Matchers
       |"correlationid":"72a89d23-0fc6-4212-92fc-ea8b05139c76"
       |}"""
       .stripMargin
+
+  private val thisMonth: LocalDate = LocalDate.now.withDayOfMonth(1)
+  private val lastMonth: LocalDate = LocalDate.now.minusMonths(1)
+  private val nextMonth: LocalDate = LocalDate.now.plusMonths(1)
+  private val inTwoMonths: LocalDate = LocalDate.now.plusMonths(2)
 
   "must call the xrs exchange rate service and receive the response" in {
 
@@ -129,4 +140,93 @@ class XrsExchangeRateRequestWorkerSpec extends AnyWordSpec with Matchers
     }
 
   }
+
+  "xrs exchange rate service call must not fail with invalid XRS file format" in {
+
+    val invalidJsonResponse = "{}"
+    server.stubFor(
+      post(urlEqualTo("/passengers/exchangerequest/xrs/getexchangerate/v1"))
+        .willReturn(aResponse().withStatus(OK).withBody(invalidJsonResponse))
+    )
+    val app = builder.build()
+    running(app) {
+      val worker = app.injector.instanceOf[XrsExchangeRateRequestWorker]
+
+      val workerResponse = worker.tap.pull.futureValue.value
+      workerResponse.status shouldBe OK
+      workerResponse.body shouldBe invalidJsonResponse
+    }
+
+  }
+
+  "areRatesForNextMonth is true if all validFrom dates start next month" in {
+    val exchangeRateData: ExchangeRateData = ExchangeRateData("", "",
+      Seq(ExchangeRate(nextMonth, inTwoMonths, "UDS", BigDecimal(0.75d), "US Dollars"),
+      ExchangeRate(nextMonth, inTwoMonths, "EU", BigDecimal(0.95d), "Euro")))
+
+    val rateRequest = new XrsExchangeRateRequest{}
+    rateRequest.areRatesForNextMonth(exchangeRateData) shouldBe(true)
+  }
+
+  "areRatesForNextMonth is false if validFrom dates have a mixture that start next month and valid from this month" in {
+    val exchangeRateData: ExchangeRateData = ExchangeRateData("", "",
+      Seq(ExchangeRate(nextMonth, inTwoMonths, "UDS", BigDecimal(0.75d), "US Dollars"),
+        ExchangeRate(thisMonth, nextMonth, "EU", BigDecimal(0.95d), "Euro")))
+
+    val rateRequest = new XrsExchangeRateRequest{}
+    rateRequest.areRatesForNextMonth(exchangeRateData) shouldBe(false)
+  }
+
+  "areRatesForNextMonth is false if all validFrom dates start this month" in {
+    val exchangeRateData: ExchangeRateData = ExchangeRateData("", "",
+      Seq(ExchangeRate(thisMonth, nextMonth, "UDS", BigDecimal(0.75d), "US Dollars"),
+        ExchangeRate(thisMonth, nextMonth, "EU", BigDecimal(0.95d), "Euro")))
+
+    val rateRequest = new XrsExchangeRateRequest{}
+    rateRequest.areRatesForNextMonth(exchangeRateData) shouldBe(false)
+  }
+
+  "areRatesForNextMonth is false if all validFrom dates are for last month" in {
+    val exchangeRateData: ExchangeRateData = ExchangeRateData("", "",
+      Seq(ExchangeRate(lastMonth, lastMonth, "UDS", BigDecimal(0.75d), "US Dollars"),
+        ExchangeRate(lastMonth, lastMonth, "EU", BigDecimal(0.95d), "Euro")))
+
+    val rateRequest = new XrsExchangeRateRequest{}
+    rateRequest.areRatesForNextMonth(exchangeRateData) shouldBe(false)
+  }
+
+  "when data not present for next month return false" in {
+    val rateRequest = new XrsExchangeRateRequest {
+      override private[workers] def now = LocalDate.of(2022, 6, 26)
+    }
+    val mockExchangeRateRepository = mock[ExchangeRateRepository]
+    doReturn(false) when mockExchangeRateRepository isDataPresent "exrates-monthly-0722"
+    rateRequest.isNextMonthsFileIsReceived(mockExchangeRateRepository) shouldBe(false)
+  }
+
+  "when data is present for next month return true" in {
+    val rateRequest = new XrsExchangeRateRequest {
+      override private[workers] def now = LocalDate.of(2022, 6, 26)
+    }
+    val mockExchangeRateRepository = mock[ExchangeRateRepository]
+    doReturn(true) when mockExchangeRateRepository isDataPresent "exrates-monthly-0722"
+    rateRequest.isNextMonthsFileIsReceived(mockExchangeRateRepository) shouldBe(true)
+  }
+
+  "checkNextMonthsFileIsReceivedDaysBeforeEndOfMonth" should {
+    "when within range to check if next months file has been received returns true" in {
+      val rateRequest = new XrsExchangeRateRequest {
+        override private[workers] def now = LocalDate.of(2022, 6, 26)
+      }
+      rateRequest.checkNextMonthsFileIsReceivedDaysBeforeEndOfMonth shouldBe (true)
+    }
+
+    "when not within range to check if next months file has been received return false" in {
+      val rateRequest = new XrsExchangeRateRequest {
+        override private[workers] def now = LocalDate.of(2022, 6, 25)
+      }
+      rateRequest.checkNextMonthsFileIsReceivedDaysBeforeEndOfMonth shouldBe (false)
+    }
+  }
+
 }


### PR DESCRIPTION
# DDCE-3135 - Currency Conversion Fix

Alert config PR : https://github.com/hmrc/alert-config/pull/2473

- On the last 5 days leading up to the next month, we need a daily PagerDuty alert/error log that informs us if XRS have not uploaded a new rates file for the next month
- Once currency-conversion has detected a new rates file for the next month, we need a PagerDuty alert/log that informs us [XRS_FILE_DETECTED_FOR_NEXT_MONTH]
- Once we have inserted a new rates file for the next month into Mongo, we need a PagerDuty alert/log that informs us [XRS_FILE_INSERTED_FOR_NEXT_MONTH] 
- Once we have inserted a new rates file for the next month into Mongo, we need a PagerDuty alert/log that informs us [XRS_EMPTY_RATES_FILE_ERROR]
- If the file is empty it should not be uploaded into Mongo (Done in a previous commit)


