### PR TITLE
DDCE-3135 - Currency Conversion Fix

### DIFF
--- a/app/uk/gov/hmrc/currencyconversion/repositories/ConversionRatePeriodJson.scala
+++ b/app/uk/gov/hmrc/currencyconversion/repositories/ConversionRatePeriodJson.scala
@@ -17,99 +17,101 @@
 package uk.gov.hmrc.currencyconversion.repositories
 
 import akka.stream.Materializer
+import play.api.i18n.Lang.logger.logger
 import play.api.libs.json.JsSuccess
+import play.api.libs.json.OFormat.oFormatFromReadsAndOWrites
 import uk.gov.hmrc.currencyconversion.models.{ConversionRatePeriod, Currency, CurrencyPeriod, ExchangeRateData}
+import uk.gov.hmrc.currencyconversion.utils.MongoIdHelper.currentFileName
 
 import java.time.LocalDate
-import play.api.i18n.Lang.logger.logger
 import javax.inject.Inject
-import play.api.libs.json.OFormat.oFormatFromReadsAndOWrites
-
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 
 
 class ConversionRatePeriodJson @Inject()(writeExchangeRateRepository: ExchangeRateRepository)
                                         (implicit ec: ExecutionContext, m: Materializer) extends ConversionRatePeriodRepository {
 
-   def getExchangeRateFileName(date : LocalDate) : String = {
-    val targetFileName = "exrates-monthly-%02d".format(date.getMonthValue) +
-      date.getYear.toString.substring(2)
+  def getExchangeRateFileName(date: LocalDate): Future[String] = {
+    val targetFileName = currentFileName(date)
 
-    if (!writeExchangeRateRepository.isDataPresent(targetFileName)) {
-      targetFileName
-    } else {
-      logger.info(s"$targetFileName is not present")
-      "empty"
+    writeExchangeRateRepository.isDataPresent(targetFileName).map {
+      case true => targetFileName
+      case _ => logger.info(s"$targetFileName is not present")
+        "empty"
     }
   }
 
-   def getExchangeRatesData(filePath: String) : Future[ExchangeRateData] = {
+  def getExchangeRatesData(filePath: String): Future[ExchangeRateData] = {
     writeExchangeRateRepository.get(filePath)
       .map {
         case response if response.isEmpty =>
           logger.error(s"XRS_FILE_CANNOT_BE_READ_ERROR [ConversionRatePeriodJson] Exchange rate file is not able to read")
           throw new RuntimeException("Exchange rate data is not able to read.")
-        case  response =>
+        case response =>
           response.get.exchangeRateData.validate[ExchangeRateData] match {
             case JsSuccess(seq, _) =>
               seq
             case _ => {
               logger.error(s"XRS_FILE_CANNOT_BE_READ_ERROR [ConversionRatePeriodJson] Exchange rate data mapping is failed")
               throw new RuntimeException("Exchange rate data mapping is failed")
+            }
           }
-        }
       }
   }
 
-   def getExchangeRates(filePath: String) : Future[Map[String, Option[BigDecimal]]] = {
+  def getExchangeRates(filePath: String): Future[Map[String, Option[BigDecimal]]] = {
 
     def getMinimumDecimalScale(rate: BigDecimal): BigDecimal = {
       if (rate.scale < 2) rate.setScale(2) else rate
     }
 
-     getExchangeRatesData(filePath).map { exchangeRates =>
-       exchangeRates.exchangeData.flatMap { data =>
-         Map(data.currencyCode -> Some(getMinimumDecimalScale(data.exchangeRate)))
-       }.toMap
-     }
+    getExchangeRatesData(filePath).map { exchangeRates =>
+      exchangeRates.exchangeData.flatMap { data =>
+        Map(data.currencyCode -> Some(getMinimumDecimalScale(data.exchangeRate)))
+      }.toMap
+    }
   }
 
-   def getCurrencies(filePath: String): Future[Seq[Currency]] = {
-     getExchangeRatesData(filePath).map { exchangeRates =>
-       exchangeRates.exchangeData map  { data =>
-         Currency("", data.currencyCode, data.currencyName)
-       }
-     }
+  def getCurrencies(filePath: String): Future[Seq[Currency]] = {
+    getExchangeRatesData(filePath).map { exchangeRates =>
+      exchangeRates.exchangeData map { data =>
+        Currency("", data.currencyCode, data.currencyName)
+      }
+    }
   }
 
   def getConversionRatePeriod(date: LocalDate): Future[Option[ConversionRatePeriod]] = {
-    val fileName = getExchangeRateFileName(date)
-    if (fileName.equals("empty")) {
-      Future.successful(None)
-    } else {
-      getExchangeRates(fileName).map { rates =>
-        Some(ConversionRatePeriod(date.withDayOfMonth(1), date.withDayOfMonth(date.lengthOfMonth()), None, rates))
+    getExchangeRateFileName(date).flatMap { fileName =>
+
+      if (fileName.equals("empty")) {
+        Future.successful(None)
+      } else {
+        getExchangeRates(fileName).map { rates =>
+          Some(ConversionRatePeriod(date.withDayOfMonth(1), date.withDayOfMonth(date.lengthOfMonth()), None, rates))
+        }
       }
     }
   }
 
   def getLatestConversionRatePeriod(date: LocalDate): Future[ConversionRatePeriod] = {
-    val fileName = getExchangeRateFileName(date)
-    if (fileName.equals("empty")) {
-      logger.error(s"XRS_FILE_NOT_AVAILABLE_ERROR [ConversionRatePeriodJson] Exchange rate file is not available.")
-      Future.failed(new RuntimeException("Exchange rate file is not able to read."))
-    } else {
-      getExchangeRates(fileName).map { rates =>
-        ConversionRatePeriod(date.withDayOfMonth(1), date.withDayOfMonth(date.lengthOfMonth()), None, rates)
+    getExchangeRateFileName(date).flatMap { fileName =>
+      if (fileName.equals("empty")) {
+        logger.error(s"XRS_FILE_NOT_AVAILABLE_ERROR [ConversionRatePeriodJson] Exchange rate file is not available.")
+        Future.failed(new RuntimeException("Exchange rate file is not able to read."))
+      } else {
+        getExchangeRates(fileName).map { rates =>
+          ConversionRatePeriod(date.withDayOfMonth(1), date.withDayOfMonth(date.lengthOfMonth()), None, rates)
+        }
       }
     }
   }
 
   def getCurrencyPeriod(date: LocalDate): Future[Option[CurrencyPeriod]] = {
-    getCurrencies(getExchangeRateFileName(date)).map { currencies =>
-      Some(CurrencyPeriod(date.withDayOfMonth(1), date.withDayOfMonth(date.lengthOfMonth()), currencies))
+    getExchangeRateFileName(date).flatMap { fileName =>
+      getCurrencies(fileName).map { currencies =>
+        Some(CurrencyPeriod(date.withDayOfMonth(1), date.withDayOfMonth(date.lengthOfMonth()), currencies))
+      }
     }
   }
 }

--- a/app/uk/gov/hmrc/currencyconversion/utils/MongoIdHelper.scala
+++ b/app/uk/gov/hmrc/currencyconversion/utils/MongoIdHelper.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.currencyconversion.utils
+
+import java.time.LocalDate
+
+object MongoIdHelper {
+
+  def currentFileName(date: LocalDate = LocalDate.now()): String = "exrates-monthly-%02d".format(date.getMonthValue) +
+    date.getYear.toString.substring(2)
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -153,6 +153,7 @@ workers {
     interval      = 1.minutes
     parallelism   = 1
     scheduled-time= false
+    next-month-alert-days = 5
   }
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,14 @@
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.3.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.7.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.1")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")

--- a/test/uk/gov/hmrc/currencyconversion/controllers/ExchangeRateControllerSpec.scala
+++ b/test/uk/gov/hmrc/currencyconversion/controllers/ExchangeRateControllerSpec.scala
@@ -49,7 +49,7 @@ class ExchangeRateControllerSpec extends AnyWordSpecLike with GuiceOneAppPerSuit
   override def beforeEach(): Unit = {
     Mockito.reset(exchangeRateRepository)
     val exchangeRate : ExchangeRateObject = ExchangeRateObject("exrates-monthly-0919", Json.parse(data).as[JsObject])
-    doReturn(false) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
+    doReturn(Future.successful(true)) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
     doReturn(successful(Some(exchangeRate))) when exchangeRateRepository get "exrates-monthly-0919"
 
     SharedMetricRegistries.clear()
@@ -160,7 +160,7 @@ class ExchangeRateControllerSpec extends AnyWordSpecLike with GuiceOneAppPerSuit
      "Getting rates for a date which has no rates Json file and a valid currency code" must {
 
        "return 200 and the correct json" in {
-         doReturn(true) when exchangeRateRepository isDataPresent "exrates-monthly-1019"
+         doReturn(Future.successful(false)) when exchangeRateRepository isDataPresent "exrates-monthly-1019"
 
          val result = route(app, FakeRequest("GET", "/currency-conversion/rates/2019-10-10?cc=USD")).get
 
@@ -172,7 +172,7 @@ class ExchangeRateControllerSpec extends AnyWordSpecLike with GuiceOneAppPerSuit
 
      "Getting rates for a date which has no rates Json file, 1 valid currency code and 1 invalid currency code" must {
        "return response from previous month" in {
-         doReturn(true) when exchangeRateRepository isDataPresent "exrates-monthly-1019"
+         doReturn(Future.successful(false)) when exchangeRateRepository isDataPresent "exrates-monthly-1019"
          val result = route(app, FakeRequest("GET", "/currency-conversion/rates/2019-10-10?cc=USD&cc=INVALID")).get
 
          status(result) shouldBe Status.OK
@@ -225,7 +225,7 @@ class ExchangeRateControllerSpec extends AnyWordSpecLike with GuiceOneAppPerSuit
        "return 200 and the correct json" in {
 
          val exchangeRate : ExchangeRateObject = ExchangeRateObject("exrates-monthly-0919", Json.parse(data).as[JsObject])
-         doReturn(false) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
+         doReturn(Future.successful(true)) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
          doReturn(successful(Some(exchangeRate))) when exchangeRateRepository get "exrates-monthly-0919"
 
          val result = route(app, FakeRequest("GET", "/currency-conversion/currencies/2019-09-01")).get
@@ -251,7 +251,7 @@ class ExchangeRateControllerSpec extends AnyWordSpecLike with GuiceOneAppPerSuit
        "return 200 if fallback is available" in {
 
          val exchangeRate : ExchangeRateObject = ExchangeRateObject("exrates-monthly-0919", Json.parse(data).as[JsObject])
-         doReturn(false) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
+         doReturn(Future.successful(true)) when exchangeRateRepository isDataPresent  "exrates-monthly-0919"
          doReturn(successful(Some(exchangeRate))) when exchangeRateRepository get "exrates-monthly-0919"
 
 

--- a/test/uk/gov/hmrc/currencyconversion/utils/MongoIdHelperSpec.scala
+++ b/test/uk/gov/hmrc/currencyconversion/utils/MongoIdHelperSpec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.currencyconversion.utils
+
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.LocalDate
+
+class MongoIdHelperSpec extends AnyWordSpec with Matchers {
+
+  val jan2011 = LocalDate.of(2011, 1, 12)
+  val dec2018 = LocalDate.of(2018, 12, 12)
+
+  "MongoIdHelper" should {
+    "get this jan 2011 current file name" in {
+      MongoIdHelper.currentFileName(jan2011) mustBe "exrates-monthly-0111"
+    }
+
+    "get this dec 2018 current file name" in {
+      MongoIdHelper.currentFileName(dec2018) mustBe "exrates-monthly-1218"
+    }
+  }
+}

--- a/test/uk/gov/hmrc/currencyconversion/workers/XrsDelayHelperSpec.scala
+++ b/test/uk/gov/hmrc/currencyconversion/workers/XrsDelayHelperSpec.scala
@@ -23,8 +23,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.currencyconversion.utils.WireMockHelper
 
-import java.time.{Instant, LocalDate, LocalDateTime, ZoneId, ZoneOffset}
-import java.util.{Calendar, TimeZone}
+import java.time.LocalDateTime
 import scala.concurrent.duration.FiniteDuration
 
 class XrsDelayHelperSpec extends AnyWordSpec with Matchers

--- a/test/uk/gov/hmrc/currencyconversion/workers/XrsExchangeRateRequestWorkerSpec.scala
+++ b/test/uk/gov/hmrc/currencyconversion/workers/XrsExchangeRateRequestWorkerSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.currencyconversion.workers
 
 
 import com.github.tomakehurst.wiremock.client.WireMock._
+import org.mockito.Mockito.doReturn
 import org.scalatest.OptionValues
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
@@ -25,7 +26,15 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers._
+import uk.gov.hmrc.currencyconversion.models.{ExchangeRate, ExchangeRateData}
+import uk.gov.hmrc.currencyconversion.repositories.ExchangeRateRepository
 import uk.gov.hmrc.currencyconversion.utils.WireMockHelper
+
+import java.time.LocalDate
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.language.postfixOps
+import scala.util.{Failure, Try}
 
 class XrsExchangeRateRequestWorkerSpec extends AnyWordSpec with Matchers
   with ScalaFutures with IntegrationPatience with OptionValues with MockitoSugar with WireMockHelper with Eventually {
@@ -47,6 +56,11 @@ class XrsExchangeRateRequestWorkerSpec extends AnyWordSpec with Matchers
       |"correlationid":"72a89d23-0fc6-4212-92fc-ea8b05139c76"
       |}"""
       .stripMargin
+
+  private val thisMonth: LocalDate = LocalDate.now.withDayOfMonth(1)
+  private val lastMonth: LocalDate = LocalDate.now.minusMonths(1)
+  private val nextMonth: LocalDate = LocalDate.now.plusMonths(1)
+  private val inTwoMonths: LocalDate = LocalDate.now.plusMonths(2)
 
   "must call the xrs exchange rate service and receive the response" in {
 
@@ -129,4 +143,120 @@ class XrsExchangeRateRequestWorkerSpec extends AnyWordSpec with Matchers
     }
 
   }
+
+  "xrs exchange rate service call must not fail with invalid XRS file format" in {
+
+    val invalidJsonResponse = "{}"
+    server.stubFor(
+      post(urlEqualTo("/passengers/exchangerequest/xrs/getexchangerate/v1"))
+        .willReturn(aResponse().withStatus(OK).withBody(invalidJsonResponse))
+    )
+    val app = builder.build()
+    running(app) {
+      val worker = app.injector.instanceOf[XrsExchangeRateRequestWorker]
+
+      val workerResponse = worker.tap.pull.futureValue.value
+      workerResponse.status shouldBe OK
+      workerResponse.body shouldBe invalidJsonResponse
+    }
+
+  }
+
+  "areRatesForNextMonth is true if all validFrom dates start next month" in {
+    val exchangeRateData: ExchangeRateData = ExchangeRateData("", "",
+      Seq(ExchangeRate(nextMonth, inTwoMonths, "UDS", BigDecimal(0.75d), "US Dollars"),
+        ExchangeRate(nextMonth, inTwoMonths, "EU", BigDecimal(0.95d), "Euro")))
+
+    val rateRequest = new XrsExchangeRateRequest {}
+    rateRequest.areRatesForNextMonth(exchangeRateData) shouldBe (true)
+  }
+
+  "areRatesForNextMonth is false if validFrom dates have a mixture that start next month and valid from this month" in {
+    val exchangeRateData: ExchangeRateData = ExchangeRateData("", "",
+      Seq(ExchangeRate(nextMonth, inTwoMonths, "UDS", BigDecimal(0.75d), "US Dollars"),
+        ExchangeRate(thisMonth, nextMonth, "EU", BigDecimal(0.95d), "Euro")))
+
+    val rateRequest = new XrsExchangeRateRequest {}
+    rateRequest.areRatesForNextMonth(exchangeRateData) shouldBe (false)
+  }
+
+  "areRatesForNextMonth is false if all validFrom dates start this month" in {
+    val exchangeRateData: ExchangeRateData = ExchangeRateData("", "",
+      Seq(ExchangeRate(thisMonth, nextMonth, "UDS", BigDecimal(0.75d), "US Dollars"),
+        ExchangeRate(thisMonth, nextMonth, "EU", BigDecimal(0.95d), "Euro")))
+
+    val rateRequest = new XrsExchangeRateRequest {}
+    rateRequest.areRatesForNextMonth(exchangeRateData) shouldBe (false)
+  }
+
+  "areRatesForNextMonth is false if all validFrom dates are for last month" in {
+    val exchangeRateData: ExchangeRateData = ExchangeRateData("", "",
+      Seq(ExchangeRate(lastMonth, lastMonth, "UDS", BigDecimal(0.75d), "US Dollars"),
+        ExchangeRate(lastMonth, lastMonth, "EU", BigDecimal(0.95d), "Euro")))
+
+    val rateRequest = new XrsExchangeRateRequest {}
+    rateRequest.areRatesForNextMonth(exchangeRateData) shouldBe (false)
+  }
+
+  "when data not present for next month return false" in {
+    val rateRequest = new XrsExchangeRateRequest {
+      override private[workers] def now = LocalDate.of(2022, 6, 26)
+    }
+    val mockExchangeRateRepository = mock[ExchangeRateRepository]
+    doReturn(Future.successful(false)) when mockExchangeRateRepository isDataPresent "exrates-monthly-0722"
+    false shouldBe await(rateRequest.isNextMonthsFileIsReceived(mockExchangeRateRepository))
+  }
+
+  "when data is present for next month return true" in {
+    val rateRequest = new XrsExchangeRateRequest {
+      override private[workers] def now = LocalDate.of(2022, 6, 26)
+    }
+    val mockExchangeRateRepository = mock[ExchangeRateRepository]
+    doReturn(Future.successful(true)) when mockExchangeRateRepository isDataPresent "exrates-monthly-0722"
+    true shouldBe await(rateRequest.isNextMonthsFileIsReceived(mockExchangeRateRepository))
+  }
+
+  "checkNextMonthsFileIsReceivedDaysBeforeEndOfMonth" should {
+    "when within range to check if next months file has been received returns true" in {
+      val rateRequest = new XrsExchangeRateRequest {
+        override private[workers] def now = LocalDate.of(2022, 6, 26)
+      }
+      rateRequest.checkNextMonthsFileIsReceivedDaysBeforeEndOfMonth shouldBe (true)
+    }
+
+    "when not within range to check if next months file has been received return false" in {
+      val rateRequest = new XrsExchangeRateRequest {
+        override private[workers] def now = LocalDate.of(2022, 6, 25)
+      }
+      rateRequest.checkNextMonthsFileIsReceivedDaysBeforeEndOfMonth shouldBe (false)
+    }
+  }
+
+  "verifyExchangeDataIsNotEmpty" should {
+
+    "is true when data is not empty" in {
+      val exchangeRateData: ExchangeRateData = ExchangeRateData("", "",
+        Seq(ExchangeRate(nextMonth, inTwoMonths, "UDS", BigDecimal(0.75d), "US Dollars"),
+          ExchangeRate(nextMonth, inTwoMonths, "EU", BigDecimal(0.95d), "Euro")))
+      val rateRequest = new XrsExchangeRateRequest {
+
+      }
+      rateRequest.verifyExchangeDataIsNotEmpty(Try(exchangeRateData)) shouldBe true
+    }
+
+    "is false when data is empty" in {
+      val exchangeRateData: ExchangeRateData = ExchangeRateData("", "", Seq())
+      val rateRequest = new XrsExchangeRateRequest {
+
+      }
+      rateRequest.verifyExchangeDataIsNotEmpty(Try(exchangeRateData)) shouldBe false
+    }
+
+    "is false when unsuccessful" in {
+      val rateRequest = new XrsExchangeRateRequest {}
+      rateRequest.verifyExchangeDataIsNotEmpty(Failure(new RuntimeException("failed"))) shouldBe false
+    }
+
+  }
+
 }


### PR DESCRIPTION
# DDCE-3135 - Currency Conversion Fix

Alert config PR : https://github.com/hmrc/alert-config/pull/2473

On the last 5 days leading up to the next month, we need a daily PagerDuty alert/error log that informs us if XRS have not uploaded a new rates file for the next month
Once currency-conversion has detected a new rates file for the next month, we need a PagerDuty alert/log that informs us [XRS_FILE_DETECTED_FOR_NEXT_MONTH]
Once we have inserted a new rates file for the next month into Mongo, we need a PagerDuty alert/log that informs us [XRS_FILE_INSERTED_FOR_NEXT_MONTH]
Once we have inserted a new rates file for the next month into Mongo, we need a PagerDuty alert/log that informs us [XRS_EMPTY_RATES_FILE_ERROR]
If the file is empty it should not be uploaded into Mongo (Done in a previous commit)