### PR TITLE
example - file fallback

### DIFF
--- a/app/uk/gov/hmrc/currencyconversion/controllers/ExchangeRateController.scala
+++ b/app/uk/gov/hmrc/currencyconversion/controllers/ExchangeRateController.scala
@@ -44,10 +44,10 @@ class ExchangeRateController @Inject() (
 
       if (exchangeRateResults.exists(result => result.isInstanceOf[ExchangeRateOldFileResult])) {
         logger.error(
-          "XRS_FILE_NOT_AVAILABLE_ERROR [ExchangeRateController] [getRatesByCurrencyCode] Using older " +
+          "[ExchangeRateController][getRatesByCurrencyCode] XRS_FILE_NOT_AVAILABLE_ERROR - Using older " +
             "XRS file as XRS file for supplied date could not be found..."
         )
-        Ok(Json.toJson(rates)).withHeaders(WARNING -> s"""299 - "Date out of range" "$dateTime"""")
+        Ok(Json.toJson(rates)).withHeaders(WARNING -> s"299 - Date out of range: $dateTime")
       } else {
         Ok(Json.toJson(rates))
       }
@@ -56,8 +56,8 @@ class ExchangeRateController @Inject() (
 
   def getCurrenciesByDate(date: LocalDate): Action[AnyContent] = Action.async {
     exchangeRatesService.getCurrencies(date).map {
-      case Some(cp) => Ok(Json.toJson(cp))
-      case None     => NotFound
+      case Right(currencyPeriod) => Ok(Json.toJson(currencyPeriod))
+      case Left(_)               => NotFound
     }
   }
 }

--- a/app/uk/gov/hmrc/currencyconversion/errors/XrsFileErrors.scala
+++ b/app/uk/gov/hmrc/currencyconversion/errors/XrsFileErrors.scala
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.currencyconversion.utils
+package uk.gov.hmrc.currencyconversion.errors
 
-import java.time.LocalDate
+sealed trait XrsFileErrors
 
-object MongoIdHelper {
+case object XrsFileMappingError extends XrsFileErrors
 
-  def currentFileName(date: LocalDate = LocalDate.now()): String =
-    "exrates-monthly-%02d".format(date.getMonthValue) + date.getYear.toString.substring(2)
+case object XrsFileNotFoundError extends XrsFileErrors
 
-}
+case object XrsFileSearchMaxNumberOfTimesError extends XrsFileErrors

--- a/app/uk/gov/hmrc/currencyconversion/repositories/ConversionRatePeriodRepository.scala
+++ b/app/uk/gov/hmrc/currencyconversion/repositories/ConversionRatePeriodRepository.scala
@@ -17,15 +17,20 @@
 package uk.gov.hmrc.currencyconversion.repositories
 
 import com.google.inject.ImplementedBy
-
-import java.time.LocalDate
+import uk.gov.hmrc.currencyconversion.errors.XrsFileErrors
 import uk.gov.hmrc.currencyconversion.models.{ConversionRatePeriod, CurrencyPeriod}
 
+import java.time.LocalDate
 import scala.concurrent.Future
 
 @ImplementedBy(classOf[ConversionRatePeriodJson])
 trait ConversionRatePeriodRepository {
-  def getConversionRatePeriod(date: LocalDate): Future[Option[ConversionRatePeriod]]
-  def getLatestConversionRatePeriod(date: LocalDate): Future[ConversionRatePeriod]
-  def getCurrencyPeriod(date: LocalDate): Future[Option[CurrencyPeriod]]
+
+  def getConversionRatePeriod(date: LocalDate): Future[Either[XrsFileErrors, ConversionRatePeriod]]
+
+  def fileLookBack[A](date: LocalDate, numberOfMonthsToLookBack: Int)(
+    f: LocalDate => Future[Either[XrsFileErrors, A]]
+  ): Future[Either[XrsFileErrors, A]]
+
+  def getCurrencyPeriod(date: LocalDate): Future[Either[XrsFileErrors, CurrencyPeriod]]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ val appName = "currency-conversion"
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
+  .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     // To resolve a bug with version 2.x.x of the scoverage plugin - https://github.com/sbt/sbt/issues/6997
     libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -130,6 +130,10 @@ mongodb {
   uri = "mongodb://localhost:27017/currency-conversion"
 }
 
+fallback {
+    months = 6
+}
+
 mongo-async-driver {
   akka {
     loglevel = WARNING

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,14 +1,16 @@
-import sbt.*
+import sbt._
 
 object AppDependencies {
 
   private lazy val bootstrapPlayVersion = "7.15.0"
   private lazy val hmrcMongoVersion     = "0.74.0"
 
-  private lazy val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % bootstrapPlayVersion,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % hmrcMongoVersion
-  )
+  private lazy val compile: Seq[ModuleID] =
+    Seq(
+      "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % bootstrapPlayVersion,
+      "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % hmrcMongoVersion,
+      "org.typelevel"     %% "cats-core"                 % "2.9.0"
+    )
 
   private lazy val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"           %% "bootstrap-test-play-28"  % bootstrapPlayVersion,

--- a/test/uk/gov/hmrc/currencyconversion/controllers/ExchangeRateControllerSpec.scala
+++ b/test/uk/gov/hmrc/currencyconversion/controllers/ExchangeRateControllerSpec.scala
@@ -17,24 +17,27 @@
 package uk.gov.hmrc.currencyconversion.controllers
 
 import com.codahale.metrics.SharedMetricRegistries
+import org.mockito.ArgumentMatchers.any
 import org.mockito.{Mockito, MockitoSugar}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.http.Status
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsArray, JsObject, Json}
+import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.currencyconversion.repositories.ExchangeRateRepository
-import play.api.Application
+import uk.gov.hmrc.currencyconversion.errors.XrsFileNotFoundError
 import uk.gov.hmrc.currencyconversion.models.ExchangeRateObject
+import uk.gov.hmrc.currencyconversion.repositories.{ConversionRatePeriodJson, ExchangeRateRepository}
 
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import scala.concurrent.Future._
-import org.scalatest.wordspec.AnyWordSpecLike
-import play.api.mvc.Result
-
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class ExchangeRateControllerSpec
     extends AnyWordSpecLike
@@ -42,11 +45,60 @@ class ExchangeRateControllerSpec
     with MockitoSugar
     with BeforeAndAfterEach {
 
-  private lazy val exchangeRateRepository = mock[ExchangeRateRepository]
+  implicit val ec = ExecutionContext.global
+
+  private lazy val exchangeRateRepository                                 = mock[ExchangeRateRepository]
+  private lazy val mockConversionRatePeriodJson: ConversionRatePeriodJson = mock[ConversionRatePeriodJson]
+
+  def exchangeRateDataJson(id: String, startDate: String, endDate: String): JsObject =
+    Json
+      .parse(
+        s"""
+           |{
+           |    "_id" : "$id",
+           |    "timestamp": "2019-06-28T13:17:21Z",
+           |    "correlationid": "c4a81105-9417-4080-9cd2-c4469efc965c",
+           |    "exchangeRates": [
+           |        {
+           |            "validFrom": "$startDate",
+           |            "validTo": "$endDate",
+           |            "currencyCode": "USD",
+           |            "exchangeRate": 1.337,
+           |            "currencyName": "US Dollars"
+           |        }
+           |    ]
+           |}
+    """.stripMargin
+      )
+      .as[JsObject]
+
+  val data: JsObject =
+    Json
+      .parse("""{
+          |        "timestamp" : "2019-06-28T13:17:21Z",
+          |        "correlationid" : "c4a81105-9417-4080-9cd2-c4469efc965c",
+          |        "exchangeRates" : [
+          |            {
+          |                "validFrom" : "2019-09-01",
+          |                "validTo" : "2019-09-30",
+          |                "currencyCode" : "USD",
+          |                "exchangeRate" : 1.213,
+          |                "currencyName" : "United State"
+          |            },
+          |            {
+          |                "validFrom" : "2019-09-01",
+          |                "validTo" : "2019-09-30",
+          |                "currencyCode" : "INR",
+          |                "exchangeRate" : 1,
+          |                "currencyName" : "India"
+          |            }
+          |        ]
+          |}""".stripMargin)
+      .as[JsObject]
 
   override def beforeEach(): Unit = {
     Mockito.reset(exchangeRateRepository)
-    val exchangeRate: ExchangeRateObject = ExchangeRateObject("exrates-monthly-0919", Json.parse(data).as[JsObject])
+    val exchangeRate: ExchangeRateObject = ExchangeRateObject("exrates-monthly-0919", data)
     doReturn(Future.successful(true)) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
     doReturn(successful(Some(exchangeRate))) when exchangeRateRepository get "exrates-monthly-0919"
 
@@ -64,55 +116,121 @@ class ExchangeRateControllerSpec
       .build()
   }
 
-  val data: String =
-    """{
-      |        "timestamp" : "2019-06-28T13:17:21Z",
-      |        "correlationid" : "c4a81105-9417-4080-9cd2-c4469efc965c",
-      |        "exchangeRates" : [
-      |            {
-      |                "validFrom" : "2019-09-01",
-      |                "validTo" : "2019-09-30",
-      |                "currencyCode" : "USD",
-      |                "exchangeRate" : 1.213,
-      |                "currencyName" : "United State"
-      |            },
-      |            {
-      |                "validFrom" : "2019-09-01",
-      |                "validTo" : "2019-09-30",
-      |                "currencyCode" : "INR",
-      |                "exchangeRate" : 1,
-      |                "currencyName" : "India"
-      |            }
-      |        ]
-      |}""".stripMargin
+  "Getting rates for a valid date and 1 valid currency" when {
 
-  "Getting rates for a valid date and 1 valid currency" must {
+    "the file date is the same as the current date" must {
 
-    "return 200 and the correct json" in {
+      "return 200 and the correct json" in {
 
-      val result = await(route(app, FakeRequest("GET", "/currency-conversion/rates/2019-09-10?cc=USD")).get)
+        val result = await(route(app, FakeRequest("GET", "/currency-conversion/rates/2019-09-10?cc=USD")).get)
 
-      result.header.status shouldBe OK
+        result.header.status shouldBe OK
 
-      result.header.headers.get("Warning") shouldBe None
+        result.header.headers.get("Warning") shouldBe None
 
-      contentAsJson(Future.successful(result)) shouldBe Json.arr(
-        Json.obj("startDate" -> "2019-09-01", "endDate" -> "2019-09-30", "currencyCode" -> "USD", "rate" -> "1.213")
-      )
-      Thread.sleep(2000.toLong)
+        contentAsJson(Future.successful(result)) shouldBe Json.arr(
+          Json.obj("startDate" -> "2019-09-01", "endDate" -> "2019-09-30", "currencyCode" -> "USD", "rate" -> "1.213")
+        )
+      }
+
+      "return 200 and the correct json with scaling 2 decimal at least" in {
+
+        val result: Result = await(route(app, FakeRequest("GET", "/currency-conversion/rates/2019-09-10?cc=INR")).get)
+
+        result.header.status shouldBe OK
+
+        result.header.headers.get("Warning") shouldBe None
+
+        contentAsJson(Future.successful(result)) shouldBe Json.arr(
+          Json.obj("startDate" -> "2019-09-01", "endDate" -> "2019-09-30", "currencyCode" -> "INR", "rate" -> "1.00")
+        )
+      }
     }
-    "return 200 and the correct json with scaling 2 decimal at least" in {
 
-      val result: Result = await(route(app, FakeRequest("GET", "/currency-conversion/rates/2019-09-10?cc=INR")).get)
+    "the file date is old but within the fall back period" must {
 
-      result.header.status shouldBe OK
+      "return 200 and the correct json" in {
 
-      result.header.headers.get("Warning") shouldBe None
+        when(exchangeRateRepository.get("exrates-monthly-1219")).thenReturn(Future(None))
+        when(exchangeRateRepository.get("exrates-monthly-1119")).thenReturn(Future(None))
+        when(exchangeRateRepository.get("exrates-monthly-1019")).thenReturn(Future(None))
+        when(exchangeRateRepository.get("exrates-monthly-0919"))
+          .thenReturn(
+            Future(
+              Some(
+                ExchangeRateObject(
+                  fileName = "exrates-monthly-0919",
+                  exchangeRateData = exchangeRateDataJson("exrates-monthly-0919", "2019-09-01", "2019-09-30")
+                )
+              )
+            )
+          )
 
-      contentAsJson(Future.successful(result)) shouldBe Json.arr(
-        Json.obj("startDate" -> "2019-09-01", "endDate" -> "2019-09-30", "currencyCode" -> "INR", "rate" -> "1.00")
-      )
-      Thread.sleep(2000.toLong)
+        when(mockConversionRatePeriodJson.getExchangeRateObjectFile(any())).thenReturn(
+          Future.successful(
+            Right(
+              ExchangeRateObject(
+                fileName = "exrates-monthly-0919",
+                exchangeRateData = exchangeRateDataJson("exrates-monthly-0919", "2019-09-01", "2019-09-30")
+              )
+            )
+          )
+        )
+
+        when(mockConversionRatePeriodJson.getConversionRatePeriod(any()))
+          .thenReturn(
+            Future(Left(XrsFileNotFoundError))
+          )
+
+        val result = await(route(app, FakeRequest("GET", "/currency-conversion/rates/2019-12-10?cc=USD")).get)
+
+        result.header.status shouldBe OK
+
+        val dateTime = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z"))
+
+        result.header.headers.get("Warning") shouldBe Some(s"299 - Date out of range: $dateTime")
+
+        contentAsJson(Future.successful(result)) shouldBe
+          Json.arr(
+            Json.obj("startDate" -> "2019-09-01", "endDate" -> "2019-09-30", "currencyCode" -> "USD", "rate" -> "1.337")
+          )
+      }
+
+      "return 200 and the correct json with scaling 2 decimal at least" in {
+
+        when(exchangeRateRepository.get("exrates-monthly-1219")).thenReturn(
+          Future.successful(
+            Some(
+              ExchangeRateObject(
+                fileName = "exrates-monthly-0919",
+                exchangeRateData = data
+              )
+            )
+          )
+        )
+
+        when(mockConversionRatePeriodJson.getExchangeRateObjectFile(any())).thenReturn(
+          Future.successful(
+            Right(
+              ExchangeRateObject(
+                fileName = "exrates-monthly-0919",
+                exchangeRateData = exchangeRateDataJson("exrates-monthly-0919", "2019-09-01", "2019-09-30")
+              )
+            )
+          )
+        )
+
+        val result: Result = await(route(app, FakeRequest("GET", "/currency-conversion/rates/2019-12-10?cc=INR")).get)
+
+        result.header.status shouldBe OK
+
+        result.header.headers.get("Warning") shouldBe None
+
+        contentAsJson(Future.successful(result)) shouldBe
+          Json.arr(
+            Json.obj("startDate" -> "2019-09-01", "endDate" -> "2019-09-30", "currencyCode" -> "INR", "rate" -> "1.00")
+          )
+      }
     }
   }
 
@@ -153,31 +271,55 @@ class ExchangeRateControllerSpec
         "endDate",
         "currencyCode"
       )
-
     }
   }
 
   "Getting rates for a date which has no rates Json file and a valid currency code" must {
 
     "return 200 and the correct json" in {
-      doReturn(Future.successful(false)) when exchangeRateRepository isDataPresent "exrates-monthly-1019"
+
+      when(exchangeRateRepository.get(any())).thenReturn(
+        Future.successful(
+          Some(
+            ExchangeRateObject(
+              fileName = "exrates-monthly-0919",
+              exchangeRateData = exchangeRateDataJson("exrates-monthly-0919", "2019-09-01", "2019-09-30")
+            )
+          )
+        )
+      )
 
       val result = route(app, FakeRequest("GET", "/currency-conversion/rates/2019-10-10?cc=USD")).get
 
       status(result) shouldBe Status.OK
 
-      contentAsJson(result).as[JsArray].value(0).as[JsObject].keys shouldBe Set(
-        "startDate",
-        "endDate",
-        "currencyCode",
-        "rate"
-      )
+      contentAsJson(result).as[JsArray].value(0).as[JsObject].keys shouldBe
+        Set(
+          "startDate",
+          "endDate",
+          "currencyCode",
+          "rate"
+        )
     }
   }
 
   "Getting rates for a date which has no rates Json file, 1 valid currency code and 1 invalid currency code" must {
+
     "return response from previous month" in {
-      doReturn(Future.successful(false)) when exchangeRateRepository isDataPresent "exrates-monthly-1019"
+
+      when(exchangeRateRepository.isDataPresent("exrates-monthly-1019")).thenReturn(Future.successful(false))
+
+      when(exchangeRateRepository.get(any())).thenReturn(
+        Future.successful(
+          Some(
+            ExchangeRateObject(
+              fileName = "exrates-monthly-0919",
+              exchangeRateData = exchangeRateDataJson("exrates-monthly-0919", "2019-09-01", "2019-09-30")
+            )
+          )
+        )
+      )
+
       val result = route(app, FakeRequest("GET", "/currency-conversion/rates/2019-10-10?cc=USD&cc=INVALID")).get
 
       status(result) shouldBe Status.OK
@@ -229,7 +371,7 @@ class ExchangeRateControllerSpec
 
     "return 200 and the correct json" in {
 
-      val exchangeRate: ExchangeRateObject = ExchangeRateObject("exrates-monthly-0919", Json.parse(data).as[JsObject])
+      val exchangeRate: ExchangeRateObject = ExchangeRateObject("exrates-monthly-0919", data)
       doReturn(Future.successful(true)) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
       doReturn(successful(Some(exchangeRate))) when exchangeRateRepository get "exrates-monthly-0919"
 
@@ -255,7 +397,7 @@ class ExchangeRateControllerSpec
 
     "return 200 if fallback is available" in {
 
-      val exchangeRate: ExchangeRateObject = ExchangeRateObject("exrates-monthly-0919", Json.parse(data).as[JsObject])
+      val exchangeRate: ExchangeRateObject = ExchangeRateObject("exrates-monthly-0919", data)
       doReturn(Future.successful(true)) when exchangeRateRepository isDataPresent "exrates-monthly-0919"
       doReturn(successful(Some(exchangeRate))) when exchangeRateRepository get "exrates-monthly-0919"
 
@@ -265,6 +407,20 @@ class ExchangeRateControllerSpec
 
       contentAsJson(result).as[JsObject].keys shouldBe Set("start", "end", "currencies")
     }
-  }
 
+    "return 404 NOT_FOUND if fallback is available" in {
+
+      when(exchangeRateRepository.get("exrates-monthly-0919")).thenReturn(Future(None))
+      when(exchangeRateRepository.get("exrates-monthly-0819")).thenReturn(Future(None))
+      when(exchangeRateRepository.get("exrates-monthly-0719")).thenReturn(Future(None))
+      when(exchangeRateRepository.get("exrates-monthly-0619")).thenReturn(Future(None))
+      when(exchangeRateRepository.get("exrates-monthly-0519")).thenReturn(Future(None))
+      when(exchangeRateRepository.get("exrates-monthly-0419")).thenReturn(Future(None))
+      when(exchangeRateRepository.get("exrates-monthly-0319")).thenReturn(Future(None))
+
+      val result = route(app, FakeRequest("GET", "/currency-conversion/currencies/2019-09-22")).get
+
+      status(result) shouldBe Status.NOT_FOUND
+    }
+  }
 }

--- a/test/uk/gov/hmrc/currencyconversion/repositories/ConversionRatePeriodJsonSpec.scala
+++ b/test/uk/gov/hmrc/currencyconversion/repositories/ConversionRatePeriodJsonSpec.scala
@@ -16,116 +16,226 @@
 
 package uk.gov.hmrc.currencyconversion.repositories
 
-import java.time.LocalDate
-
 import org.mockito.ArgumentMatchers.any
 import org.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+import play.api.Configuration
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers._
+import uk.gov.hmrc.currencyconversion.errors._
 import uk.gov.hmrc.currencyconversion.models._
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 
+import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class ConversionRatePeriodJsonSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
+class ConversionRatePeriodJsonSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with MockitoSugar
+    with DefaultPlayMongoRepositorySupport[ExchangeRateObject] {
+
+  val emptyExchangeRateDataModel =
+    ExchangeRateObject(
+      fileName = "exrates-monthly-0923",
+      exchangeRateData = JsObject.empty
+    ).exchangeRateData
+
+  val feb2023 =
+    ExchangeRateObject(
+      fileName = "exrates-monthly-0223",
+      exchangeRateData = exchangeRateDataJson("exrates-monthly-0223", "2023-02-01", "2023-02-28")
+    )
+
+  val july2023 =
+    ExchangeRateObject(
+      fileName = "exrates-monthly-0723",
+      exchangeRateData = exchangeRateDataJson("exrates-monthly-0723", "2023-07-01", "2023-07-30")
+    )
+
+  val aug2023 =
+    ExchangeRateObject(
+      fileName = "exrates-monthly-0823",
+      exchangeRateData = exchangeRateDataJson("exrates-monthly-0823", "2023-08-01", "2023-08-30")
+    ).exchangeRateData
+
+  val sept2023 =
+    ExchangeRateObject(
+      fileName = "exrates-monthly-0923",
+      exchangeRateData = exchangeRateDataJson("exrates-monthly-0923", "2023-09-01", "2023-09-30")
+    ).exchangeRateData
 
   private val mockExchangeRateRepository: ExchangeRateRepository = mock[ExchangeRateRepository]
 
-  private val conversionRatePeriodJson: ConversionRatePeriodJson = new ConversionRatePeriodJson(
-    mockExchangeRateRepository
-  )
+  private val mockConfiguration: Configuration = mock[Configuration]
 
-  private val exchangeRateData: ExchangeRateData = ExchangeRateData(
-    timestamp = "2019-06-28T13:17:21Z",
-    correlationId = "c4a81105-9417-4080-9cd2-c4469efc965c",
-    exchangeData = Seq(
-      ExchangeRate(
-        validFrom = LocalDate.parse("2019-09-01"),
-        validTo = LocalDate.parse("2019-09-30"),
-        currencyCode = "INR",
-        exchangeRate = 1.213,
-        currencyName = "Indian rupee"
+  //  private val fallBackMonthLimit = mockConfiguration[Int]("fallback.months")
+  private val fallBackMonthLimit = 6
+
+  override def repository: DefaultExchangeRateRepository = new DefaultExchangeRateRepository(mongoComponent)
+
+  private val conversionRatePeriodJson: ConversionRatePeriodJson =
+    new ConversionRatePeriodJson(mockExchangeRateRepository)
+
+  val realConversionRatePeriodJson: ConversionRatePeriodJson =
+    new ConversionRatePeriodJson(repository)
+
+  private val exchangeRateData: ExchangeRateData =
+    ExchangeRateData(
+      timestamp = "2019-06-28T13:17:21Z",
+      correlationId = "c4a81105-9417-4080-9cd2-c4469efc965c",
+      exchangeData = Seq(
+        ExchangeRate(
+          validFrom = LocalDate.parse("2019-09-01"),
+          validTo = LocalDate.parse("2019-09-30"),
+          currencyCode = "INR",
+          exchangeRate = 1.213,
+          currencyName = "Indian rupee"
+        )
       )
     )
-  )
 
-  private val exchangeRateDataJson: JsObject = Json
+  override def beforeEach(): Unit =
+    prepareDatabase()
+
+  def exchangeRateDataJson(id: String, startDate: String, endDate: String): JsObject = Json
     .parse(
-      """
-      |{
-      |    "timestamp": "2019-06-28T13:17:21Z",
-      |    "correlationid": "c4a81105-9417-4080-9cd2-c4469efc965c",
-      |    "exchangeRates": [
-      |        {
-      |            "validFrom": "2019-09-01",
-      |            "validTo": "2019-09-30",
-      |            "currencyCode": "INR",
-      |            "exchangeRate": 1.213,
-      |            "currencyName": "Indian rupee"
-      |        }
-      |    ]
-      |}
+      s"""
+         |{
+         |    "_id" : "$id",
+         |    "timestamp": "2019-06-28T13:17:21Z",
+         |    "correlationid": "c4a81105-9417-4080-9cd2-c4469efc965c",
+         |    "exchangeRates": [
+         |        {
+         |            "validFrom": "$startDate",
+         |            "validTo": "$endDate",
+         |            "currencyCode": "INR",
+         |            "exchangeRate": 1.213,
+         |            "currencyName": "Indian rupee"
+         |        }
+         |    ]
+         |}
     """.stripMargin
     )
     .as[JsObject]
 
   "ConversionRatePeriodJson" when {
+
     ".getExchangeRatesData" should {
+
       "return exchange rate data" in {
+
         when(mockExchangeRateRepository.get(any())).thenReturn(
           Future.successful(
             Some(
               ExchangeRateObject(
                 fileName = "exrates-monthly-0919",
-                exchangeRateData = exchangeRateDataJson
+                exchangeRateData = exchangeRateDataJson("exrates-monthly-0919", "2019-09-01", "2019-09-30")
               )
             )
           )
         )
 
-        val result: ExchangeRateData = await(conversionRatePeriodJson.getExchangeRatesData("exrates-monthly-1019"))
+        val actual   = await(conversionRatePeriodJson.getExchangeRatesData(LocalDate.parse("2019-10-01")))
+        val expected = Right(exchangeRateData)
 
-        result shouldBe exchangeRateData
+        actual shouldBe expected
       }
 
       "throw RuntimeException" when {
+
         "no exchange rate data is present" in {
+
           when(mockExchangeRateRepository.get(any())).thenReturn(Future.successful(None))
 
-          intercept[RuntimeException] {
-            await(conversionRatePeriodJson.getExchangeRatesData("exrates-monthly-1019"))
-          }.getMessage shouldBe "Exchange rate data is not able to read."
+          val actual   = await(conversionRatePeriodJson.getExchangeRatesData(LocalDate.parse("2019-09-01")))
+          val expected = Left(XrsFileMappingError)
+
+          actual shouldBe expected
         }
 
         "the exchange rate data present does not match the model" in {
+
           when(mockExchangeRateRepository.get(any())).thenReturn(
-            Future.successful(
+            Future(
               Some(
-                ExchangeRateObject(
-                  fileName = "exrates-monthly-0919",
-                  exchangeRateData = JsObject.empty
-                )
+                ExchangeRateObject(fileName = "exrates-monthly-0919", exchangeRateData = JsObject.empty)
               )
             )
           )
 
-          intercept[RuntimeException] {
-            await(conversionRatePeriodJson.getExchangeRatesData("exrates-monthly-1019"))
-          }.getMessage shouldBe "Exchange rate data mapping is failed"
+          val actual   = await(conversionRatePeriodJson.getExchangeRatesData(LocalDate.parse("2019-10-01")))
+          val expected = Left(XrsFileMappingError)
+
+          actual shouldBe expected
         }
       }
     }
 
     ".getLatestConversionRatePeriod" should {
+
       "throw RuntimeException" when {
+
         "no exchange rate data is present" in {
+
           when(mockExchangeRateRepository.isDataPresent(any())).thenReturn(Future.successful(false))
 
-          intercept[RuntimeException] {
-            await(conversionRatePeriodJson.getLatestConversionRatePeriod(LocalDate.parse("2019-09-01")))
-          }.getMessage shouldBe "Exchange rate file is not able to read."
+          val actual   = await(conversionRatePeriodJson.getExchangeRatesData(LocalDate.parse("2019-09-01")))
+          val expected = Left(XrsFileMappingError)
+
+          actual shouldBe expected
+        }
+      }
+    }
+
+    ".fileLookBack()" when {
+
+      "given a desired date, with a file with a date within the lookback period, SUCCESSFULLY retrieve the fallback file" should {
+
+        "return a Right(ConversionRatePeriod) exchange rate data for July 2023, for the desired date of September 2023" in {
+
+          repository.testOnlyInsert(july2023.exchangeRateData, "exrates-monthly-0723")
+
+          val actual =
+            await(
+              realConversionRatePeriodJson.fileLookBack[ConversionRatePeriod](
+                desiredFileDate = LocalDate.parse("2023-09-01"),
+                fallBackMonthLimit
+              )(realConversionRatePeriodJson.getConversionRatePeriod)
+            )
+
+          val expected =
+            Right(
+              ConversionRatePeriod(
+                startDate = LocalDate.parse("2023-07-01"),
+                endDate = LocalDate.parse("2023-07-31"),
+                currencyCode = None,
+                rates = Map("INR" -> Some(1.213))
+              )
+            )
+
+          actual shouldBe expected
+        }
+      }
+
+      "given a date outside the fallback range, FAILS to retrieves any file" should {
+
+        "return a Left(XrsFileSearchMaxNumberOfTimesError) for data outside the fallback date range" in {
+
+          repository.testOnlyInsert(feb2023.exchangeRateData, "exrates-monthly-0223")
+
+          val actual =
+            await(
+              realConversionRatePeriodJson.fileLookBack[ConversionRatePeriod](
+                desiredFileDate = LocalDate.parse("2023-09-01"),
+                fallBackMonthLimit
+              )(realConversionRatePeriodJson.getConversionRatePeriod)
+            )
+
+          val expected = Left(XrsFileSearchMaxNumberOfTimesError)
+          actual shouldBe expected
         }
       }
     }

--- a/test/uk/gov/hmrc/currencyconversion/repositories/DefaultExchangeRateRepositorySpec.scala
+++ b/test/uk/gov/hmrc/currencyconversion/repositories/DefaultExchangeRateRepositorySpec.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.currencyconversion.repositories
 
-import java.time.LocalDate
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.libs.json.{JsObject, Json}
@@ -26,6 +24,7 @@ import uk.gov.hmrc.currencyconversion.models._
 import uk.gov.hmrc.currencyconversion.utils.MongoIdHelper.currentFileName
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 
+import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class DefaultExchangeRateRepositorySpec
@@ -35,29 +34,27 @@ class DefaultExchangeRateRepositorySpec
 
   override def repository: DefaultExchangeRateRepository = new DefaultExchangeRateRepository(mongoComponent)
 
-  override def afterEach(): Unit = {
-    super.afterEach()
+  override def beforeEach(): Unit =
     prepareDatabase()
-  }
 
   private val date: LocalDate = LocalDate.now()
 
   private val exchangeRateDataJson: JsObject = Json
     .parse(
       """
-      |{
-      |    "timestamp": "2019-06-28T13:17:21Z",
-      |    "correlationid": "c4a81105-9417-4080-9cd2-c4469efc965c",
-      |    "exchangeRates": [
-      |        {
-      |            "validFrom": "2019-09-01",
-      |            "validTo": "2019-09-30",
-      |            "currencyCode": "INR",
-      |            "exchangeRate": 1.213,
-      |            "currencyName": "India"
-      |        }
-      |    ]
-      |}
+        |{
+        |    "timestamp": "2019-06-28T13:17:21Z",
+        |    "correlationid": "c4a81105-9417-4080-9cd2-c4469efc965c",
+        |    "exchangeRates": [
+        |        {
+        |            "validFrom": "2019-09-01",
+        |            "validTo": "2019-09-30",
+        |            "currencyCode": "INR",
+        |            "exchangeRate": 1.213,
+        |            "currencyName": "India"
+        |        }
+        |    ]
+        |}
     """.stripMargin
     )
     .as[JsObject]
@@ -65,19 +62,19 @@ class DefaultExchangeRateRepositorySpec
   private val updatedExchangeRateDataJson: JsObject = Json
     .parse(
       """
-      |{
-      |    "timestamp": "2020-06-28T13:17:21Z",
-      |    "correlationid": "c4a81105-9417-4080-9cd2-c4469efc965c",
-      |    "exchangeRates": [
-      |        {
-      |            "validFrom": "2020-09-01",
-      |            "validTo": "2020-09-30",
-      |            "currencyCode": "INR",
-      |            "exchangeRate": 1.213,
-      |            "currencyName": "India"
-      |        }
-      |    ]
-      |}
+        |{
+        |    "timestamp": "2020-06-28T13:17:21Z",
+        |    "correlationid": "c4a81105-9417-4080-9cd2-c4469efc965c",
+        |    "exchangeRates": [
+        |        {
+        |            "validFrom": "2020-09-01",
+        |            "validTo": "2020-09-30",
+        |            "currencyCode": "INR",
+        |            "exchangeRate": 1.213,
+        |            "currencyName": "India"
+        |        }
+        |    ]
+        |}
     """.stripMargin
     )
     .as[JsObject]
@@ -93,8 +90,11 @@ class DefaultExchangeRateRepositorySpec
   }
 
   "DefaultExchangeRateRepository" when {
+
     ".insert" should {
+
       "insert exchange rate data" when {
+
         "current month" in {
           repository.insert(exchangeRateData = exchangeRateDataJson) shouldBe ()
         }
@@ -106,6 +106,7 @@ class DefaultExchangeRateRepositorySpec
     }
 
     ".isDataPresent" should {
+
       "return false" when {
         "checking if exchange rate data exists in the next two months" in new Setup {
           await(repository.isDataPresent(currentFileName(date.plusMonths(2)))) shouldBe false
@@ -124,7 +125,9 @@ class DefaultExchangeRateRepositorySpec
     }
 
     ".get" should {
+
       "return None" when {
+
         "checking if exchange rate data exists in the next two months" in new Setup {
           await(repository.get(currentFileName(date.plusMonths(2)))) shouldBe None
         }
@@ -144,7 +147,9 @@ class DefaultExchangeRateRepositorySpec
     }
 
     ".update" should {
+
       "update exchange rate data" when {
+
         "current month" in new Setup {
           repository.update(exchangeRateData = updatedExchangeRateDataJson) shouldBe ()
         }
@@ -156,16 +161,21 @@ class DefaultExchangeRateRepositorySpec
     }
 
     ".insertOrUpdate" should {
+
       "return None" when {
+
         "inserting exchange rate data for current month where no data exists" in {
           await(repository.insertOrUpdate(exchangeRateDataJson)) shouldBe None
+          repository.collection.drop()
         }
 
         "updating exchange rate data for current month where data exists" in new Setup {
           await(repository.insertOrUpdate(updatedExchangeRateDataJson)) shouldBe None
+          repository.collection.drop()
         }
 
         "a six month old exchange rate data exists" in {
+
           val monthsToSubtract: Long = 6
 
           await(

--- a/test/uk/gov/hmrc/currencyconversion/services/ExchangeRateServiceSpec.scala
+++ b/test/uk/gov/hmrc/currencyconversion/services/ExchangeRateServiceSpec.scala
@@ -16,24 +16,28 @@
 
 package uk.gov.hmrc.currencyconversion.services
 
-import java.time.LocalDate
-
 import org.mockito.ArgumentMatchers.any
 import org.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+import play.api.Configuration
+import play.api.libs.json.Json
 import play.api.test.Helpers._
+import uk.gov.hmrc.currencyconversion.errors._
 import uk.gov.hmrc.currencyconversion.models._
 import uk.gov.hmrc.currencyconversion.repositories.ConversionRatePeriodRepository
 
+import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class ExchangeRateServiceSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
 
   private val mockConversionRatePeriodRepository: ConversionRatePeriodRepository = mock[ConversionRatePeriodRepository]
+  private val mockConfiguration: Configuration                                   = mock[Configuration]
 
-  private val exchangeRateService: ExchangeRateService = new ExchangeRateService(mockConversionRatePeriodRepository)
+  private val exchangeRateService: ExchangeRateService =
+    new ExchangeRateService(mockConversionRatePeriodRepository, mockConfiguration)
 
   private val currencies: Seq[Currency] = Seq(
     Currency(
@@ -50,18 +54,144 @@ class ExchangeRateServiceSpec extends AnyWordSpecLike with Matchers with Mockito
   )
 
   "ExchangeRateService" when {
-    ".getCurrencies" should {
-      "return currency period" in {
-        when(mockConversionRatePeriodRepository.getCurrencyPeriod(any()))
-          .thenReturn(Future.successful(Some(currencyPeriod)))
 
-        await(exchangeRateService.getCurrencies(LocalDate.parse("2019-09-01"))) shouldBe Some(currencyPeriod)
+    ".getFallbackConversionRatePeriod()" when {
+
+      "the file date is the same as current month" should {
+
+        "return ExchangeRateSuccessResult with the correct json" in {
+
+          when(mockConversionRatePeriodRepository.fileLookBack[ConversionRatePeriod](any(), any())(any()))
+            .thenReturn(
+              Future(
+                Right(
+                  ConversionRatePeriod(
+                    startDate = LocalDate.parse("2023-09-01"),
+                    endDate = LocalDate.parse("2023-09-30"),
+                    currencyCode = Some("INR"),
+                    rates = Map("INR" -> Some(1.213))
+                  )
+                )
+              )
+            )
+
+          val expectedJson =
+            Json.obj(
+              "startDate"    -> "2023-09-01",
+              "endDate"      -> "2023-09-30",
+              "currencyCode" -> "INR",
+              "rate"         -> "1.213"
+            )
+
+          val actual   = await(exchangeRateService.getFallbackConversionRatePeriod(LocalDate.parse("2023-09-01"), "INR"))
+          val expected = ExchangeRateOldFileResult(expectedJson)
+
+          actual shouldBe expected
+        }
+      }
+
+      "the file date is the same as current month but with no rate" should {
+
+        "return ExchangeRateSuccessResult with the correct json" in {
+
+          when(mockConversionRatePeriodRepository.fileLookBack[ConversionRatePeriod](any(), any())(any()))
+            .thenReturn(
+              Future(
+                Right(
+                  ConversionRatePeriod(
+                    startDate = LocalDate.parse("2023-09-01"),
+                    endDate = LocalDate.parse("2023-09-30"),
+                    currencyCode = Some("INR"),
+                    rates = Map()
+                  )
+                )
+              )
+            )
+
+          val expectedJson =
+            Json.obj(
+              "startDate"    -> "2023-09-01",
+              "endDate"      -> "2023-09-30",
+              "currencyCode" -> "INR"
+            )
+
+          val actual   = await(exchangeRateService.getFallbackConversionRatePeriod(LocalDate.parse("2023-09-01"), "INR"))
+          val expected = ExchangeRateOldFileResult(expectedJson)
+
+          actual shouldBe expected
+        }
+      }
+
+      "the file is within the look back period" should {
+
+        "return ExchangeRateOldFileResult with the correct json" in {
+
+          when(mockConversionRatePeriodRepository.fileLookBack[ConversionRatePeriod](any(), any())(any()))
+            .thenReturn(
+              Future(
+                Right(
+                  ConversionRatePeriod(
+                    startDate = LocalDate.parse("2023-07-01"),
+                    endDate = LocalDate.parse("2023-07-31"),
+                    currencyCode = Some("INR"),
+                    rates = Map("INR" -> Some(1.213))
+                  )
+                )
+              )
+            )
+
+          val expectedJson =
+            Json.obj(
+              "startDate"    -> "2023-07-01",
+              "endDate"      -> "2023-07-31",
+              "currencyCode" -> "INR",
+              "rate"         -> "1.213"
+            )
+
+          val actual   = await(exchangeRateService.getFallbackConversionRatePeriod(LocalDate.parse("2019-09-01"), "INR"))
+          val expected = ExchangeRateOldFileResult(expectedJson)
+
+          actual shouldBe expected
+        }
+      }
+
+      "the file is too old so is NOT within the look back period" should {
+
+        "throw an exception" in {
+
+          when(mockConversionRatePeriodRepository.fileLookBack[ConversionRatePeriod](any(), any())(any()))
+            .thenReturn(Future(Left(XrsFileSearchMaxNumberOfTimesError)))
+
+          intercept[Exception] {
+            await(exchangeRateService.getFallbackConversionRatePeriod(LocalDate.parse("2019-09-01"), "INR"))
+          }.getMessage shouldBe
+            "[ExchangeRateService][lookBackAndGetFallbackData] Look back fail with error: XrsFileSearchMaxNumberOfTimesError"
+        }
+      }
+    }
+
+    ".getCurrencies" should {
+
+      "return currency period" in {
+
+        when(mockConversionRatePeriodRepository.getCurrencyPeriod(any()))
+          .thenReturn(Future(Right(currencyPeriod)))
+
+        when(mockConversionRatePeriodRepository.fileLookBack[CurrencyPeriod](any(), any())(any()))
+          .thenReturn(Future(Right(currencyPeriod)))
+
+        await(exchangeRateService.getCurrencies(LocalDate.parse("2019-09-01"))) shouldBe Right(currencyPeriod)
       }
 
       "return None" in {
-        when(mockConversionRatePeriodRepository.getCurrencyPeriod(any())).thenReturn(Future.successful(None))
 
-        await(exchangeRateService.getCurrencies(LocalDate.parse("2019-09-01"))) shouldBe None
+        when(mockConversionRatePeriodRepository.getCurrencyPeriod(any()))
+          .thenReturn(Future(Left(XrsFileMappingError)))
+
+        when(mockConversionRatePeriodRepository.fileLookBack[CurrencyPeriod](any(), any())(any()))
+          .thenReturn(Future(Left(XrsFileMappingError)))
+
+        await(exchangeRateService.getCurrencies(LocalDate.parse("2019-09-01"))) shouldBe Left(XrsFileMappingError)
       }
     }
   }

--- a/test/uk/gov/hmrc/currencyconversion/workers/XrsExchangeRateRequestWorkerSpec.scala
+++ b/test/uk/gov/hmrc/currencyconversion/workers/XrsExchangeRateRequestWorkerSpec.scala
@@ -84,7 +84,7 @@ class XrsExchangeRateRequestWorkerSpec
 
   }
 
-  "Handle the service unavailable response from Xrs service" in {
+  "handle the service unavailable response from Xrs service" in {
 
     server.stubFor(
       post(urlEqualTo("/passengers/exchangerequest/xrs/getexchangerate/v1"))
@@ -146,7 +146,6 @@ class XrsExchangeRateRequestWorkerSpec
       workerResponse.status shouldBe OK
       workerResponse.body   shouldBe invalidJsonResponse
     }
-
   }
 
   "xrs exchange rate service call must not fail with invalid XRS file format" in {


### PR DESCRIPTION
~~breaking coverage needs more tests~~
coverage met and added unit tests for file lookback but can still add more tests to increase confidence for the lookback period + currently missing config key is not tested

Note to manually test  stop the currency conversion and BC_PASSENGERS_EXCHANGE_RATE_STUB. 
Then create test json and edit all the dates according to a scenario.

~~Just realised the fallback is not stack safe since Future.flatMap is not stack safe. Which is a shame.~~
https://typelevel.org/cats/faq.html#i-am-new-to-pure-functional-programming-what-quick-wins-can-i-get-from-cats
looks like recursing futures in this way is fine